### PR TITLE
added staro specific code for ik-server

### DIFF
--- a/jsk_ik_server/euslisp/ik-server-impl/staro-ik-server.l
+++ b/jsk_ik_server/euslisp/ik-server-impl/staro-ik-server.l
@@ -1,0 +1,35 @@
+
+#!/usr/bin/env roseus
+
+(ros::load-ros-manifest "jsk_ik_server")
+
+;;(require "package://hrpsys_ros_bridge_tutorials/euslisp/staro-interface.l")
+(require :staro "package://hrpsys_ros_bridge_tutorials/models/staro.l")
+(when (probe-file (ros::resolve-ros-path "package://hrpsys_ros_bridge_tutorials/euslisp/staro-utils.l"))
+  (require :staro-utils "package://hrpsys_ros_bridge_tutorials/euslisp/staro-utils.l"))
+(require "package://jsk_ik_server/euslisp/ik-server.l")
+
+(ros::roseus "staro_ik_server")
+
+(defclass staro-ik-server
+  :super ik-server
+  )
+
+(defmethod staro-ik-server
+  (:init
+   (&rest args)
+   (setq robot (staro))
+   (send-super* :init
+		:robot robot
+		:ik-server-name "staro_ik_server"
+		:ik-server-service-name "/solve_ik"
+		:root-link-frame-id nil
+		args)
+   (send self :update-support-links '(:rleg :lleg))
+   (send self :make-foot-convex :force? t)
+   (send self :make-centroid-object)
+   )
+  )
+
+(defvar *staro-ik-server* (instance staro-ik-server :init))
+(send *staro-ik-server* :start-ik-server)

--- a/jsk_ik_server/test/fullbody-ik-client-test.l
+++ b/jsk_ik_server/test/fullbody-ik-client-test.l
@@ -116,6 +116,17 @@
     (send *hrp2jsk* :fix-leg-to-coords (make-coords))
     (send* self :test-fullbody-ik :robot *hrp2jsk* args))
    )
+  (:staro-test
+   (&rest args)
+   (require "package://hrpsys_ros_bridge_tutorials/models/staro.l")
+   (defvar *staro* (staro))
+   (objects (list *staro*))
+   (ros::roseus "fullbody_ik_client_test")
+   (do-until-key
+    (send *staro* :reset-manip-pose)
+    (send *staro* :fix-leg-to-coords (make-coords))
+    (send* self :test-fullbody-ik :robot *staro* args))
+   )
   (:atlas-test
    (&rest args)
    (require "package://hrpsys_gazebo_atlas/euslisp/atlas-model.l")
@@ -173,6 +184,8 @@
     (send ik-client-test :hrp2jsknt-test :foot? foot?))
    ((substringp "hrp2jsk" test)
     (send ik-client-test :hrp2jsk-test :foot? foot?))
+   ((substringp "staro" test)
+    (send ik-client-test :staro-test :foot? foot?))
    ((substringp "pr2" test)
     (send ik-client-test :pr2-test :foot? foot?))
    ((substringp "atlas" test)

--- a/jsk_ik_server/test/staro-ik-server-test.launch
+++ b/jsk_ik_server/test/staro-ik-server-test.launch
@@ -1,0 +1,18 @@
+<launch>
+  <node pkg="roseus" type="roseus" name="staro_ik_server" output="screen"
+	args="$(find jsk_ik_server)/euslisp/ik-server-impl/staro-ik-server.l">
+    <param name="robot" value="staro"/>
+    <remap to="/staro_ik_server/solve" from="/solve_ik" />
+  </node>
+  <!--
+  <node pkg="roseus" type="roseus" name="atlas_ik_client" output="screen"
+	args="$(find jsk_ik_server)/euslisp/old-ik-client.l">
+    <param name="root_link" value="/pelvis"/>
+  </node>
+  -->
+  <node pkg="roseus" type="roseus" name="staro_ik_client" output="screen"
+	args="$(find jsk_ik_server)/test/fullbody-ik-client-test.l">
+    <env name="IK_CLIENT_TEST" value="staro"/>
+    <remap to="/staro_ik_server/solve" from="/solve_ik" />
+  </node>
+</launch>


### PR DESCRIPTION
とりあえず現在の仕様でstaroを使えるようにするための
コードを追加しました．

``` bash
roslaunch jsk_ik_server staro-ik-server-test.launch
```

でランダム指令サンプルが立ち上がります．
