### PR TITLE
fix midi_config_player for groovy

### DIFF
--- a/jsk_teleop_joy/scripts/midi_config_player.py
+++ b/jsk_teleop_joy/scripts/midi_config_player.py
@@ -9,11 +9,11 @@ import roslib
 
 try:
   from sensor_msgs.msg import Joy, JoyFeedbackArray
+  from jsk_teleop_joy.midi_util import MIDIParse, MIDICommand, MIDIException, openMIDIInputByName, openMIDIOutputByName
 except:
   roslib.load_manifest('jsk_teleop_joy')
   from sensor_msgs.msg import Joy, JoyFeedbackArray
-
-from jsk_teleop_joy.midi_util import MIDIParse, MIDICommand, MIDIException, openMIDIInputByName, openMIDIOutputByName
+  from jsk_teleop_joy.midi_util import MIDIParse, MIDICommand, MIDIException, openMIDIInputByName, openMIDIOutputByName
 
 def feedback_array_cb(out_controller, config, msg_arr):
   output_config = config["output"]


### PR DESCRIPTION
#30 だとgroovyで動かした時にエラーが出ることが分かったので、修正しました。

これでgroovyでもhydroでも動くはずです。
