### PR TITLE
eus_nlopt catkinize 

### DIFF
--- a/eus_nlopt/CMakeLists.txt
+++ b/eus_nlopt/CMakeLists.txt
@@ -1,5 +1,12 @@
-project(eus_nlopt_wrapper)
+##if(NOT (USE_ROSBUILD OR "$ENV{BUILDER}" STREQUAL "rosbuild"))
+if(NOT USE_ROSBUILD)
+  message("  eus_nlopt: use catkin_make")
+  include(catkin.cmake)
+  return()
+endif()
 
+project(eus_nlopt)
+message("  eus_nlopt: use rosmake")
 #include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 cmake_minimum_required(VERSION 2.4.6)
 

--- a/eus_nlopt/Makefile
+++ b/eus_nlopt/Makefile
@@ -1,2 +1,2 @@
-#EXTRA_CMAKE_FLAGS = -DUSE_ROSBUILD:BOOL=1
+EXTRA_CMAKE_FLAGS = -DUSE_ROSBUILD:BOOL=1
 include $(shell rospack find mk)/cmake.mk

--- a/eus_nlopt/catkin.cmake
+++ b/eus_nlopt/catkin.cmake
@@ -1,0 +1,58 @@
+project(eus_nlopt)
+
+cmake_minimum_required(VERSION 2.4.6)
+
+find_package(catkin REQUIRED COMPONENTS nlopt)
+find_package(Eigen REQUIRED)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR}/src)
+include("./path-tricker/includes.txt")
+
+## catkin
+if(nlopt_FOUND_CATKIN_PROJECT)
+  ##
+  set(NLOPT_FOUND true)
+  if(NOT ${nlopt_INCLUDE_DIRS} STREQUAL "")
+    FIND_PATH(NLOPT_INCLUDE_DIR nlopt.h PATHS ${nlopt_INCLUDE_DIRS})
+  else()
+    FIND_PATH(NLOPT_INCLUDE_DIR nlopt.h PATHS ${nlopt_SOURCE_PREFIX}/include)
+  endif()
+  ##
+  SET (NLOPT_NAMES nlopt nlopt_cxx)
+  if(NOT ${nlopt_LIBRARY_DIRS} STREQUAL "")
+    FIND_LIBRARY (NLOPT_LIBRARY NAMES ${NLOPT_NAMES} PATHS ${nlopt_LIBRARY_DIRS})
+  else()
+    FIND_LIBRARY (NLOPT_LIBRARY NAMES ${NLOPT_NAMES} PATHS ${nlopt_SOURCE_PREFIX}/lib)
+  endif()
+  SET (NLOPT_LIBRARIES ${NLOPT_LIBRARY})
+  ##
+  include_directories(${NLOPT_INCLUDE_DIR})
+  MARK_AS_ADVANCED (NLOPT_LIBRARY NLOPT_INCLUDE_DIR)
+  MESSAGE("-- NLopt found (include: " ${NLOPT_INCLUDE_DIR} ", link: "  ${NLOPT_LIBRARY} ")")
+else ()
+  MESSAGE("-- NLopt missing")
+endif()
+
+catkin_package(
+  CATKIN_DEPENDS nlopt
+  DEPENDS
+  INCLUDE_DIRS
+  LIBRARIES
+)
+
+set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
+set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
+
+## add_executable(nlopt_test src/test.cpp src/nlopt_solver.cpp)
+## add_library(nlopt_solver SHARED src/nlopt_solver.cpp)
+add_library(nlopt_wrapper SHARED src/nlopt_wrapper.cpp src/nlopt_solver.cpp)
+#add_executable(nlopt_wrapper_test src/nlopt_wrapper.cpp src/nlopt_solver.cpp)
+
+#rosbuild_genmsg()
+
+if(NLOPT_FOUND)
+##  TARGET_LINK_LIBRARIES(nlopt_test ${NLOPT_LIBRARY})
+##  TARGET_LINK_LIBRARIES(nlopt_wrapper_test ${NLOPT_LIBRARY})
+  TARGET_LINK_LIBRARIES(nlopt_wrapper ${NLOPT_LIBRARY})
+endif(NLOPT_FOUND)

--- a/eus_nlopt/euslisp/nlopt.l
+++ b/eus_nlopt/euslisp/nlopt.l
@@ -1,4 +1,30 @@
-(defvar *nlopt-plugin* (load-foreign "../lib/libnlopt_wrapper.so"))
+;; (defvar *nlopt-plugin* (load-foreign "../lib/libnlopt_wrapper.so"))
+(defvar *nlopt-plugin*
+  (labels
+      ((library_search
+	(str &key
+	     (depth 0)
+	     colon-pos lib-path)
+	(format t "  [~A] target=" depth)
+	(cond
+	 ((eq (length str) 0)
+	  (format t "~% nlopt_plugin_not_found in nlopt.l~%")
+	  (exit -1))
+	 ((and (setq colon-pos (or (position #\: str) (length str)))
+	       (setq lib-path (subseq str 0 colon-pos))
+	       (setq lib-path
+		     (if (eq (aref lib-path (- (length lib-path) 1)) #\/)
+			 (subseq lib-path 0 (- (length lib-path) 1))
+		       lib-path))
+	       (probe-file (setq lib-path
+				 (print (format nil "~A/libnlopt_wrapper.so" lib-path)))))
+	  (load-foreign lib-path))
+	 (t
+	  (library_search (subseq str (min (length str) (+ colon-pos 1)))
+			  :depth (+ depth 1))))))
+    (library_search (format nil "~A:~A/lib"
+			    (unix:getenv "LD_LIBRARY_PATH")
+			    (read-line (piped-fork "rospack find eus_nlopt"))))))
 
 ;; algorithm
 (defconstant DIRECT 0)
@@ -199,7 +225,7 @@
   ret
   )
 
-(defun test nil
+(defun test-nlopt nil
   (dolist
       (alg
        (list DIRECT

--- a/eus_nlopt/package.xml
+++ b/eus_nlopt/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package>
+  <name> eus_nlopt </name>
+  <description>
+    eus_nlopt
+  </description>
+  <version>0.0.0</version>
+  <maintainer email="s-noda@jsk.t.u-tokyo.ac.jp">Noda Shintaro</maintainer>
+  <license>Apache License 2.0</license>
+  <export> </export>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>euslisp</build_depend>
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>nlopt</build_depend>
+  <run_depend>euslisp</run_depend>
+  <run_depend>nlopt</run_depend>
+</package>


### PR DESCRIPTION
see `eus_nlopt catkinize #38`.
This PR combines every commits of #38.

catkinize eus_nlopt.
add package.xml.
nlopt.l searches library files from LD_LIBRARY_PATH.

test
roseus "(progn (load \"nlopt.l\") (test-nlopt))"
