### PR TITLE
ik server publishes posestamped of default-end-coords

### DIFF
--- a/jsk_ik_server/euslisp/ik-server.l
+++ b/jsk_ik_server/euslisp/ik-server.l
@@ -76,7 +76,8 @@
       (apply
        #'append
        (mapcar
-	#'(lambda (k) (if (find-method robot k) (list (cons k (send robot k :end-coords)))))
+	#'(lambda (k) (if (and (find-method robot k) (send robot k))
+			  (list (cons k (send robot k :end-coords)))))
 	'(:rarm :larm :rleg :lleg))))
     (ik-server-client
      (instance fullbody-ik-client :init))
@@ -174,16 +175,39 @@
    )
   (:loop-ik-server
    nil
+   (send self :publish-default-end-coords :init? t)
    (do-until-key
     (if (not (ros::ok)) (return-from nil nil))
     (unless (or (null x::*display*) (= x::*display* 0))
       (x::window-main-one))
+    (ros::spin-once)
+    (send self :publish-default-end-coords :init? nil)
     (ros::sleep)
-    (ros::spin-once))
+    ;;(unix:usleep (* 100 1000))
+    )
    )
   ;;
   ;;
   ;;
+  (:publish-default-end-coords
+   (&key (init? nil))
+   (mapcar
+    #'(lambda (dec)
+	(if init?
+	    (ros::advertise
+	     (format nil "~A/default_end_coords/~A"
+		     ik-server-name
+		     (remove #\: (format nil "~A" (car dec))))
+	     geometry_msgs::posestamped 1))
+	(ros::publish
+	 (format nil "~A/default_end_coords/~A"
+		 ik-server-name
+		 (remove #\: (format nil "~A" (car dec))))
+	 (send ik-server-client :coords2posestamped
+	       (send (cdr dec) :copy-worldcoords)
+	       :robot robot))
+	)
+    default-end-coords))
   (:local-transform
    (frame-id
     pose


### PR DESCRIPTION
add publish statement of default end coords as posestameped message, frame_id = root-link

topic name = pr2_ik_server/default_end_coords/larm etc..
