### PR TITLE
add :ik-server-name args, smaple robot has name with - charactre

### DIFF
--- a/jsk_ik_server/euslisp/ik-server-impl/sample-robot-ik-server.l
+++ b/jsk_ik_server/euslisp/ik-server-impl/sample-robot-ik-server.l
@@ -8,5 +8,5 @@
 
 (ros::roseus "sample_robot_ik_server")
 
-(defvar *sample-robot-ik-server* (instance ik-server :init :robot (instance sample-robot :init)))
+(defvar *sample-robot-ik-server* (instance ik-server :init :robot (instance sample-robot :init) :ik-server-name "sample_robot_ik_server"))
 (send *sample-robot-ik-server* :start-ik-server)


### PR DESCRIPTION
see #88.

travis test failed because sample-robot has name with - character.
