### PR TITLE
add pr2_relay.launch

### DIFF
--- a/jsk_teleop_joy/launch/pr2_relay.launch
+++ b/jsk_teleop_joy/launch/pr2_relay.launch
@@ -1,0 +1,25 @@
+<launch>
+  <arg name="DEV" default="/dev/input/js0" />
+  <arg name="CONTROLLER_TYPE" default="auto" />
+  <arg name="joy_topic" default="$(anon joy)" />
+  <node pkg="joy" type="joy_node" name="$(arg joy_topic)" output="screen" >
+    <param name="dev" type="string" value="$(arg DEV)" />
+    <remap from="/joy" to="$(arg joy_topic)" />
+    <param name="deadzone" value="0.2" />
+    <param name="autorepeat_rate" value="40" />
+    <param name="coalesce_interval" value="0.025" />
+  </node>
+  <node pkg="jsk_teleop_joy" type="joy.py" name="joy_manager" output="screen"
+        clear_params="true">
+    <param name="controller_type" value="auto" />
+    <remap from="/joy" to="$(arg joy_topic)" />
+    <rosparam subst_value="true">
+      plugins:
+        'PR2 original':
+           class: 'RelayAndConvertToPS3'
+           args:
+             output_topic: /joy_other
+             joy_mux: /multiple_joystick_mux
+    </rosparam>
+  </node>
+</launch>


### PR DESCRIPTION
pr1012とペアリングされているpsコントローラーの調子が悪かったので、xboxコントローラーなどをパソコンにつないで指令を送ることができるlaunchファイルを植田さんに書いていただきました。
