### PR TITLE
roseus only needs runtime

### DIFF
--- a/jsk_footstep_planner/catkin.cmake
+++ b/jsk_footstep_planner/catkin.cmake
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_footstep_planner)
 
-find_package(catkin REQUIRED COMPONENTS jsk_footstep_msgs jsk_pcl_ros roseus)
+find_package(catkin REQUIRED COMPONENTS jsk_footstep_msgs jsk_pcl_ros)
 #catkin_python_setup()
 catkin_package(
   DEPENDS
-  CATKIN-DEPENDS  jsk_footstep_msgs jsk_pcl_ros roseus
+  CATKIN-DEPENDS  jsk_footstep_msgs jsk_pcl_ros
   INCLUDE_DIRS # TODO include
   LIBRARIES # TODO
   )

--- a/jsk_footstep_planner/package.xml
+++ b/jsk_footstep_planner/package.xml
@@ -19,7 +19,6 @@
   <build_depend>jsk_pcl_ros</build_depend>
   <run_depend>jsk_pcl_ros</run_depend>
 
-  <build_depend>roseus</build_depend>
   <run_depend>roseus</run_depend>
   
   <export>


### PR DESCRIPTION
- jsk_footstep_controller failed to compile during roseus message generation, it seems something wrong on roseus message genrator code, but we can avoid this by removing roseus from build_depend
- See http://jenkins.ros.org/view/HbinP32/job/ros-hydro-jsk-footstep-controller_binarydeb_precise_i386/30/console
