### PR TITLE
[joy_mouse] Add name API to lookup device by name

### DIFF
--- a/joy_mouse/launch/trackpoint.launch
+++ b/joy_mouse/launch/trackpoint.launch
@@ -6,6 +6,7 @@
         output="screen"
         >
     <param name="dev" value="$(arg DEV)" />
+    <!-- <param name="device_name" value="TPPS/2 IBM TrackPoint" /> -->
     <remap from="joy" to="/trackpoint/joy" />
   </node>
 

--- a/joy_mouse/package.xml
+++ b/joy_mouse/package.xml
@@ -8,8 +8,10 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>python-pyudev</build_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>python-pyudev</run_depend>
   <export>
   </export>
 </package>

--- a/joy_mouse/scripts/disable_mouse.py
+++ b/joy_mouse/scripts/disable_mouse.py
@@ -7,7 +7,14 @@ try:
 except:
     import roslib; roslib.load_manifest("joy_mouse")
     import joy_mouse.xinput
+    
+import joy_mouse.joy
 
 if __name__ == "__main__":
     rospy.init_node("disbale_mouse")
-    joy_mouse.xinput.disableDeviceByRegexp(rospy.myargv()[1])
+    argv = rospy.myargv()
+    if "--name" == argv[1]:      #usage is disable_mouse.py --name foo
+        dev = joy_mouse.joy.lookupDeviceFileByNameAttribute(argv[2])
+    else:
+        dev = argv[1]
+    joy_mouse.xinput.disableDeviceByRegexp(dev)

--- a/joy_mouse/scripts/enable_mouse.py
+++ b/joy_mouse/scripts/enable_mouse.py
@@ -7,7 +7,14 @@ try:
 except:
     import roslib; roslib.load_manifest("joy_mouse")
     import joy_mouse.xinput
+    
+import joy_mouse.joy
 
 if __name__ == "__main__":
     rospy.init_node("enabale_mouse")
-    joy_mouse.xinput.enableDeviceByRegexp(rospy.myargv()[1])
+    argv = rospy.myargv()
+    if "--name" == argv[1]:      #usage is disable_mouse.py --name foo
+        dev = joy_mouse.joy.lookupDeviceFileByNameAttribute(argv[2])
+    else:
+        dev = argv[1]
+    joy_mouse.xinput.enableDeviceByRegexp(dev)

--- a/joy_mouse/scripts/mouse.py
+++ b/joy_mouse/scripts/mouse.py
@@ -10,7 +10,12 @@ except:
     
 if __name__ == "__main__":
     rospy.init_node("joy_mouse")
-    joy_mouse.joy.main(rospy.get_param("~dev", "/dev/input/mouse0"),
+    device_name = rospy.get_param("~dev_name", False)
+    if device_name:
+        dev = lookupDeviceFileByNameAttribute(device_name)
+    else:
+        dev = rospy.get_param("~dev", "/dev/input/mouse0")
+    joy_mouse.joy.main(dev,
                        rospy.get_param("~autorepeat_rate", 0),
                        rospy.get_param("~frame_id", "mouse"))
     

--- a/joy_mouse/src/joy_mouse/joy.py
+++ b/joy_mouse/src/joy_mouse/joy.py
@@ -4,6 +4,8 @@ import rospy
 import struct
 import select
 import os
+import pyudev
+
 try:
     from sensor_msgs.msg import Joy
 except:
@@ -11,6 +13,20 @@ except:
     from sensor_msgs.msg import Joy
 
     #def main(device_name, rate, frame_id):
+
+def lookupDeviceFileByNameAttribute(name, prefix="mouse"):
+    """
+    lookup device by name attribute. You can check name by
+    udevadmin info -a -n /dev/input/mouse0
+    """
+    context = pyudev.Context()
+    for device in context.list_devices(subsystem="input"):
+        for a in device.attributes:
+            if a == "name" and device.attributes[a] == name:
+                for child in device.children:
+                    if child.sys_name.startswith(prefix):
+                        return os.path.join("/dev", "input", child.sys_name)
+    
 def main(device_name, autorepeat_rate, frame_id):
     rospy.loginfo("reading %s" % (device_name))
     joy_pub = rospy.Publisher('joy', Joy)


### PR DESCRIPTION
Specifying device by name instead of device file.

* enable_mouse.py and disable_mouse.py

  You can use --name option like:
  ```
enable_mouse.py --name "TPPS/2 IBM TrackPoint"
```

* mouse.py

   You can use `~dev_name` parameter to specify the name of the device.

You can check name of your device by `udevadmin`.

In the following example, device name is `TPPS/2 IBM TrackPoint`.

```
$ udevadm info -a -n /dev/input/mouse0 

Udevadm info starts with the device specified by the devpath and then
walks up the chain of parent devices. It prints for every device
found, all possible attributes in the udev rules key format.
A rule to match, can be composed by the attributes of the device
and the attributes from one single parent device.

  looking at device '/devices/platform/i8042/serio1/input/input7/mouse0':
    KERNEL=="mouse0"
    SUBSYSTEM=="input"
    DRIVER==""

  looking at parent device '/devices/platform/i8042/serio1/input/input7':
    KERNELS=="input7"
    SUBSYSTEMS=="input"
    DRIVERS==""
    ATTRS{name}=="TPPS/2 IBM TrackPoint"
    ATTRS{phys}=="isa0060/serio1/input0"
...
```