### PR TITLE
[eus_qp] Fix for indigo. 

### DIFF
--- a/eus_qp/CMakeLists.txt
+++ b/eus_qp/CMakeLists.txt
@@ -2,7 +2,7 @@ project(eus_qp)
 
 cmake_minimum_required(VERSION 2.4.6)
 
-find_package(catkin COMPONENTS cmake_modules)
+find_package(catkin COMPONENTS cmake_modules roscpp)
 find_package(Eigen REQUIRED)
 
 include_directories(${Eigen_INCLUDE_DIRS})

--- a/eus_qp/package.xml
+++ b/eus_qp/package.xml
@@ -12,6 +12,7 @@
   <build_depend>euslisp</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
+  <build_depend>roscpp</build_depend>
   <run_depend>euslisp</run_depend>
   <run_depend>eigen</run_depend>
 </package>

--- a/eus_qp/src/qp_lib.cpp
+++ b/eus_qp/src/qp_lib.cpp
@@ -2,6 +2,21 @@
 #include <iostream>
 #include <Eigen/Dense>
 
+// hack
+#include <ros/common.h>
+#if ROS_VERSION_GE(ROS_VERSION_MAJOR, ROS_VERSION_MINOR, ROS_VERSION_PATCH, 1, 11, 10)
+namespace Eigen 
+{
+  namespace internal
+  {
+    float abs(float a) { return std::abs(a); }
+    float sqrt(float v) { return ::sqrt(v); }
+  }
+}
+#endif
+
+//#define Eigen::interal::abs std::abs
+
 #include "eiquadprog.hpp"
 
 using namespace Eigen;


### PR DESCRIPTION
Eigen3 on indigo may not provide Eigen::internal::sqrt

Eigen::internal::abs, in order to provide them, we define these function in qp_lib.cpp
before including qp stuff.

https://github.com/jsk-ros-pkg/jsk_control/issues/208