### PR TITLE
[jsk_footstep_planner] separate standalone utility functions into footstp_planner_util.l

### DIFF
--- a/jsk_footstep_planner/euslisp/footstep_planner.l
+++ b/jsk_footstep_planner/euslisp/footstep_planner.l
@@ -1,5 +1,9 @@
 (load "models/arrow-object.l")
 (load "models/single-arrow-object.l")
+(comp:compile-file-if-src-newer
+  (format nil "~A/euslisp/footstep_planner_util.l"
+          (ros::rospack-find "jsk_footstep_planner")))
+(load "footstep_planner_util.l")
 
 (defclass footstep-parameter
   :super propertied-object
@@ -114,87 +118,6 @@ footstep-parameter"))
 (send coords :rotate (asin (norm axis)) axis* :world)
 (send coords :x-axis)
 |#
-
-(defun project-coords-on-to-plane (coords planes z-axis)
-  (let ((point (send coords :worldpos)))
-    ;; first, creating line from the point and z-axis
-    ;; and, compute the points projected on the planes
-    ;; x = P + aZ: line
-    ;; nx + D = 0: plane
-    ;; n(P + aZ) + D = 0
-    ;; nP + anZ + D = 0
-    ;; anZ = -(D + nP)
-    ;; a = -(D + nP) / nZ
-    (let ((candidates (mapcar #'(lambda (pln)
-                                  (let ((projected-point (send pln :project point)))
-                                    ;; (ros::ros-info "projection result: ~A"
-                                    ;;                (send pln :insidep projected-point))
-                                    (if (not (eq (send pln :insidep projected-point) :outside))
-                                        ;;t
-                                        (let* ((n (send pln :normal))
-                                               (nf (matrix-column
-                                                    (send (send coords :copy-worldcoords) :worldrot) 2)))
-                                          (if (< (v. nf n) 0)
-                                              (setq n (scale -1.0 n)))
-                                          (let ((ret (send coords :copy-worldcoords)))
-                                            (send ret :locate projected-point :world)
-                                            (if (eps= (norm (v* n nf)) 0)
-                                                ret
-                                              (let* ((b (v* nf n))
-                                                     (b* (normalize-vector b))
-                                                     (theta (asin (norm b))))
-                                                ;;(send ret :rotate theta b* :world)
-                                                (send ret :rotate theta b* :local)
-                                                ret))))
-                                      nil)))
-                              planes)))
-      (let ((non-null-candidates (remove-if #'null candidates)))
-        ;; (ros::ros-info "project coordinates to ~A planes" (length non-null-candidates))
-        ;; (ros::ros-info "  ~A planes" (length planes))
-        ;; (ros::ros-info "  ~A failed to project" (- (length candidates) (length non-null-candidates)))
-        (if non-null-candidates non-null-candidates ;car is not good
-          nil)))))
-
-(defun project-coords-on-to-plane2 (coords planes z-axis)
-  (let ((point (send coords :worldpos)))
-    ;; first, creating line from the point and z-axis
-    ;; and, compute the points projected on the planes
-    ;; x = P + aZ: line
-    ;; nx + D = 0: plane
-    ;; n(P + aZ) + D = 0
-    ;; nP + anZ + D = 0
-    ;; anZ = -(D + nP)
-    ;; a = -(D + nP) / nZ
-    (let ((candidates (mapcar #'(lambda (pln)
-                                  (let ((projected-point
-                                         (let ((plane-normal (send pln :normal))
-                                               (plane-D (- (send pln :plane-distance (float-vector 0 0 0)))))
-                                           (let ((alpha (/ (- plane-D (v. plane-normal point))
-                                                           (v. plane-normal z-axis))))
-                                             (v+ point (scale alpha z-axis))))))
-                                    (if (not (eq (send pln :insidep projected-point) :outside))
-                                        (let* ((n (send pln :normal))
-                                               (nf (matrix-column
-                                                    (send (send coords :copy-worldcoords) :worldrot) 2)))
-                                          (if (< (v. nf n) 0)
-                                              (setq n (scale -1.0 n)))
-                                          (let ((ret (send coords :copy-worldcoords)))
-                                            (send ret :locate projected-point :world)
-                                            (if (eps= (norm (v* n nf)) 0)
-                                                ret
-                                              (let* ((b (v* nf n))
-                                                     (b* (normalize-vector b))
-                                                     (theta (asin (norm b))))
-                                                (send ret :rotate theta b* :world)
-                                                ret))
-                                            ret)))))
-                              planes)))
-      (let ((non-null-candidates (remove-if #'null candidates)))
-        (ros::ros-info "project coordinates to ~A planes" (length non-null-candidates))
-        (ros::ros-info "  ~A planes" (length planes))
-        (ros::ros-info "  ~A failed to project" (- (length candidates) (length non-null-candidates)))
-        (if non-null-candidates non-null-candidates ;car is not good
-          nil)))))
 
 
 (defun leg-index->leg-symbol (index)

--- a/jsk_footstep_planner/euslisp/footstep_planner_util.l
+++ b/jsk_footstep_planner/euslisp/footstep_planner_util.l
@@ -1,0 +1,82 @@
+;; utility function for footstep planning
+
+(defun project-coords-on-to-plane (coords planes z-axis)
+  "z-axis is dummy parameter.
+
+sample:
+(send-all (project-coords-on-to-plane
+           (make-coords) (send (make-cube 100 100 100) :faces)
+           (float-vector 0 0 1))
+          :draw-on :flush t)"
+  (let ((point (send coords :worldpos)))
+    (let ((candidates (mapcar #'(lambda (pln)
+                                  (let ((projected-point (send pln :project point)))
+                                    ;; (ros::ros-info "projection result: ~A"
+                                    ;;                (send pln :insidep projected-point))
+                                    (if (not (eq (send pln :insidep projected-point) :outside))
+                                        ;;t
+                                        (let* ((n (send pln :normal))
+                                               (nf (matrix-column
+                                                    (send (send coords :copy-worldcoords) :worldrot) 2)))
+                                          (if (< (v. nf n) 0)
+                                              (setq n (scale -1.0 n)))
+                                          (let ((ret (send coords :copy-worldcoords)))
+                                            (send ret :locate projected-point :world)
+                                            (if (eps= (norm (v* n nf)) 0)
+                                                ret
+                                              (let* ((b (v* nf n))
+                                                     (b* (normalize-vector b))
+                                                     (theta (asin (norm b))))
+                                                ;;(send ret :rotate theta b* :world)
+                                                (send ret :rotate theta b* :local)
+                                                ret))))
+                                      nil)))
+                              planes)))
+      (let ((non-null-candidates (remove-if #'null candidates)))
+        ;; (ros::ros-info "project coordinates to ~A planes" (length non-null-candidates))
+        ;; (ros::ros-info "  ~A planes" (length planes))
+        ;; (ros::ros-info "  ~A failed to project" (- (length candidates) (length non-null-candidates)))
+        (if non-null-candidates non-null-candidates ;car is not good
+          nil)))))
+
+(defun project-coords-on-to-plane2 (coords planes z-axis)
+  (let ((point (send coords :worldpos)))
+    ;; first, creating line from the point and z-axis
+    ;; and, compute the points projected on the planes
+    ;; x = P + aZ: line
+    ;; nx + D = 0: plane
+    ;; n(P + aZ) + D = 0
+    ;; nP + anZ + D = 0
+    ;; anZ = -(D + nP)
+    ;; a = -(D + nP) / nZ
+    (let ((candidates (mapcar #'(lambda (pln)
+                                  (let ((projected-point
+                                         (let ((plane-normal (send pln :normal))
+                                               (plane-D (- (send pln :plane-distance (float-vector 0 0 0)))))
+                                           (let ((alpha (/ (- plane-D (v. plane-normal point))
+                                                           (v. plane-normal z-axis))))
+                                             (v+ point (scale alpha z-axis))))))
+                                    (if (not (eq (send pln :insidep projected-point) :outside))
+                                        (let* ((n (send pln :normal))
+                                               (nf (matrix-column
+                                                    (send (send coords :copy-worldcoords) :worldrot) 2)))
+                                          (if (< (v. nf n) 0)
+                                              (setq n (scale -1.0 n)))
+                                          (let ((ret (send coords :copy-worldcoords)))
+                                            (send ret :locate projected-point :world)
+                                            (if (eps= (norm (v* n nf)) 0)
+                                                ret
+                                              (let* ((b (v* nf n))
+                                                     (b* (normalize-vector b))
+                                                     (theta (asin (norm b))))
+                                                (send ret :rotate theta b* :world)
+                                                ret))
+                                            ret)))))
+                              planes)))
+      (let ((non-null-candidates (remove-if #'null candidates)))
+        (ros::ros-info "project coordinates to ~A planes" (length non-null-candidates))
+        (ros::ros-info "  ~A planes" (length planes))
+        (ros::ros-info "  ~A failed to project" (- (length candidates) (length non-null-candidates)))
+        (if non-null-candidates non-null-candidates ;car is not good
+          nil)))))
+


### PR DESCRIPTION
@snozawa 
for example, 
```
(send-all (project-coords-on-to-plane
           (make-coords) (send (make-cube 100 100 100) :faces)
           (float-vector 0 0 1))
          :draw-on :flush t)
```

![screenshot_from_2015-03-18 01 51 07](https://cloud.githubusercontent.com/assets/40454/6692664/6d76a91c-cd11-11e4-81c8-69757a7ac7d0.png)
