### PR TITLE
	[jsk_footste_controller] Fix odom_on_ground consistency but ignore correctness during single stance phase

### DIFF
--- a/jsk_footstep_controller/include/jsk_footstep_controller/footcoords.h
+++ b/jsk_footstep_controller/include/jsk_footstep_controller/footcoords.h
@@ -147,11 +147,12 @@ namespace jsk_footstep_controller
     std::string rfoot_frame_id_;
     std::string lfoot_sensor_frame_;
     std::string rfoot_sensor_frame_;
+    std::string root_frame_id_;
     tf::Transform ground_transform_;
     tf::Transform midcoords_;
+    tf::Transform root_link_pose_;
     tf::Transform locked_midcoords_to_odom_on_ground_;
     boost::shared_ptr<diagnostic_updater::Updater> diagnostic_updater_;
-    
     double prev_lforce_;
     double prev_rforce_;
     double alpha_;

--- a/jsk_footstep_controller/src/footcoords.cpp
+++ b/jsk_footstep_controller/src/footcoords.cpp
@@ -194,12 +194,12 @@ namespace jsk_footstep_controller
     else if (support_status_ == LLEG_GROUND) {
       publishState("lfoot");
       success_to_update = computeMidCoordsFromSingleLeg(event.current_real, true);
-      updateGroundTF();
+      //updateGroundTF();
     }
     else if (support_status_ == RLEG_GROUND) {
       publishState("rfoot");
       success_to_update = computeMidCoordsFromSingleLeg(event.current_real, false);
-      updateGroundTF();
+      //updateGroundTF();
     }
     if (success_to_update) {
       publishTF(event.current_real);


### PR DESCRIPTION
```
odom ---> BODY --> ground (midcoords of the legs)
    +---> odom_on_ground
```

We use the same transformation about odom -> odom_on_ground to BODY -> ground.

It's simpler implementation than before but it work.
However it cannot compute correct **ground** coordinates during single stance phase.
