### PR TITLE
[jsk_footstep_controller] Publish synchronized forces from foot_coords

### DIFF
--- a/jsk_footstep_controller/catkin.cmake
+++ b/jsk_footstep_controller/catkin.cmake
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 add_message_files(FILES
-  GroundContactState.msg)
+  GroundContactState.msg FootCoordsLowLevelInfo.msg SynchronizedForces.msg)
 
 add_service_files(FILES
   RequireLog.srv RequireMonitorStatus.srv)
@@ -23,7 +23,7 @@ add_action_files(
   FILES LookAroundGround.action
 )
 generate_messages(
-  DEPENDENCIES actionlib_msgs std_msgs)
+  DEPENDENCIES actionlib_msgs std_msgs geometry_msgs)
 
 catkin_package(
 #  INCLUDE_DIRS include

--- a/jsk_footstep_controller/include/jsk_footstep_controller/footcoords.h
+++ b/jsk_footstep_controller/include/jsk_footstep_controller/footcoords.h
@@ -46,6 +46,8 @@
 #include <tf/transform_listener.h>
 #include <tf/transform_broadcaster.h>
 #include <jsk_footstep_controller/GroundContactState.h>
+#include <jsk_footstep_controller/FootCoordsLowLevelInfo.h>
+#include <jsk_footstep_controller/SynchronizedForces.h>
 #include <nav_msgs/Odometry.h>
 
 namespace jsk_footstep_controller
@@ -103,8 +105,11 @@ namespace jsk_footstep_controller
     
     // methods
 
-    virtual void filter(const geometry_msgs::WrenchStamped::ConstPtr& lfoot,
-                        const geometry_msgs::WrenchStamped::ConstPtr& rfoot);
+    /* 
+     * virtual void filter(const geometry_msgs::WrenchStamped::ConstPtr& lfoot,
+     *                     const geometry_msgs::WrenchStamped::ConstPtr& rfoot);
+     */
+    virtual void filter(const jsk_footstep_controller::SynchronizedForces::ConstPtr& msg);
     virtual bool computeMidCoords(const ros::Time& stamp);
     virtual bool computeMidCoordsFromSingleLeg(const ros::Time& stamp,
                                                bool use_left_leg);
@@ -122,21 +127,27 @@ namespace jsk_footstep_controller
                                     double threshold);
     virtual bool allValueSmallerThan(TimeStampedVector<ValueStamped::Ptr>& values,
                                      double threshold);
-    virtual bool resolveForceTf(const geometry_msgs::WrenchStamped::ConstPtr& lfoot,
-                                const geometry_msgs::WrenchStamped::ConstPtr& rfoot,
+    virtual bool resolveForceTf(const geometry_msgs::WrenchStamped& lfoot,
+                                const geometry_msgs::WrenchStamped& rfoot,
                                 tf::Vector3& lfoot_force, tf::Vector3& rfoot_force);
     virtual void periodicTimerCallback(const ros::TimerEvent& event);
     virtual void odomCallback(const nav_msgs::Odometry::ConstPtr& odom_msg);
+    virtual void synchronizeForces(const geometry_msgs::WrenchStamped::ConstPtr& lfoot,
+                                   const geometry_msgs::WrenchStamped::ConstPtr& rfoot);
     // ros variables
     boost::mutex mutex_;
     Eigen::Affine3d odom_pose_;
     ros::Timer periodic_update_timer_;
     ros::Subscriber odom_sub_;
+    ros::Subscriber synchronized_forces_sub_;
     message_filters::Subscriber<geometry_msgs::WrenchStamped> sub_lfoot_force_;
     message_filters::Subscriber<geometry_msgs::WrenchStamped> sub_rfoot_force_;
     boost::shared_ptr<message_filters::Synchronizer<SyncPolicy> >sync_;
+    
     ros::Publisher pub_state_;
     ros::Publisher pub_contact_state_;
+    ros::Publisher pub_low_level_;
+    ros::Publisher pub_synchronized_forces_;
     boost::shared_ptr<tf::TransformListener> tf_listener_;
     tf::TransformBroadcaster tf_broadcaster_;
     // parameters
@@ -161,8 +172,6 @@ namespace jsk_footstep_controller
     double prev_rforce_;
     double alpha_;
     double sampling_time_;
-    TimeStampedVector<ValueStamped::Ptr> lforce_list_;
-    TimeStampedVector<ValueStamped::Ptr> rforce_list_;
   private:
   };
 }

--- a/jsk_footstep_controller/msg/FootCoordsLowLevelInfo.msg
+++ b/jsk_footstep_controller/msg/FootCoordsLowLevelInfo.msg
@@ -1,0 +1,6 @@
+Header header
+float64 raw_lleg_force
+float64 raw_rleg_force
+float64 filtered_lleg_force
+float64 filtered_rleg_force
+float64 threshold

--- a/jsk_footstep_controller/msg/SynchronizedForces.msg
+++ b/jsk_footstep_controller/msg/SynchronizedForces.msg
@@ -1,0 +1,3 @@
+Header header
+geometry_msgs/WrenchStamped lleg_force
+geometry_msgs/WrenchStamped rleg_force


### PR DESCRIPTION
* Publish synchronized forces from foot_coords subscribe it from foot_coords internally.
* Update alpha (low pass filter parameter) to 0.1 from 0.5.
* Update queue length not to drop messages.

![screenshot_from_2015-07-11 15 45 57](https://cloud.githubusercontent.com/assets/40454/8632788/ad48a4b8-27e4-11e5-9502-653b9fffae7c.png)
