### PR TITLE
[eus_qp] add translational sliding constraint

### DIFF
--- a/eus_qp/euslisp/contact-optimization.l
+++ b/eus_qp/euslisp/contact-optimization.l
@@ -437,11 +437,14 @@
    e.g. When slide-axis is :x, this cnstarint consists of sliding constraint of x and friction constraint of y."
    (setq mu-trans tmp-mu-trans norm-axis tmp-norm-axis slide-axis tmp-slide-axis)
    (setq constraint-param-list
-         (append (calc-constraint-param-list-for-translational-sliding
-                  mu-trans norm-axis slide-axis)
-                 (calc-constraint-param-list-for-translational-friction
-                  mu-trans norm-axis (sliding-axis->no-sliding-axis slide-axis))
-                 ))
+         (let ((ret
+                (list (calc-constraint-param-list-for-translational-sliding
+                       mu-trans norm-axis slide-axis)
+                      (calc-constraint-param-list-for-translational-friction
+                       mu-trans norm-axis (sliding-axis->no-sliding-axis slide-axis)))))
+           (list :matrix (apply #'append (mapcar #'(lambda (x) (cadr (memq :matrix x))) ret))
+                 :vector (apply #'append (mapcar #'(lambda (x) (cadr (memq :vector x))) ret)))
+           ))
    (send-super :init))
   (:gen-drawing-object
    (&key (z-length 200))
@@ -451,17 +454,17 @@
            ((or (equal slide-axis :x) (equal slide-axis :-x))
             (list
              (float-vector 0 0 0)
-             (float-vector (* (axis->sgn slide-axis) mu-trans z-length) (* 1 mu-trans z-length) z-length)
-             (float-vector (* (axis->sgn slide-axis) mu-trans z-length) (* -1 mu-trans z-length) z-length))
+             (float-vector (* -1 (axis->sgn slide-axis) mu-trans z-length) (* 1 mu-trans z-length) z-length)
+             (float-vector (* -1 (axis->sgn slide-axis) mu-trans z-length) (* -1 mu-trans z-length) z-length))
             )
            ((or (equal slide-axis :y) (equal slide-axis :-y))
             (list
              (float-vector 0 0 0)
-             (float-vector (* 1 mu-trans z-length) (* (axis->sgn slide-axis) mu-trans z-length) z-length)
-             (float-vector (* -1 mu-trans z-length) (* (axis->sgn slide-axis) mu-trans z-length) z-length))
+             (float-vector (* 1 mu-trans z-length) (* -1 (axis->sgn slide-axis) mu-trans z-length) z-length)
+             (float-vector (* -1 mu-trans z-length) (* -1 (axis->sgn slide-axis) mu-trans z-length) z-length))
             ))
           1))
-   (send drawing-object :put :draw-on-args (list :color #f(1 1 0) :width 3))
+   (send drawing-object :put :draw-on-args (list :color #f(1 1 1) :width 3))
    )
   )
 
@@ -472,7 +475,7 @@
 
 (defmethod default-contact-constraint
   (:init
-   (&key (mu-trans) (mu-rot)
+   (&key (mu-trans) (mu-rot) (slide-axis)
          (l-max-x) (l-max-y) (l-min-x) (l-min-y)
          (name))
    "Calc default constraint matrix.
@@ -481,7 +484,9 @@
    (setq contact-constraint-list
          (list
            ;; friction
-           (instance 2D-translational-friction-contact-constraint :init mu-trans)
+          (if slide-axis
+              (instance 2D-translational-sliding-contact-constraint :init mu-trans :slide-axis slide-axis)
+              (instance 2D-translational-friction-contact-constraint :init mu-trans))
            (instance rotational-friction-contact-constraint :init mu-rot :fz)
            ;; cop
            (instance 2D-cop-contact-constraint :init l-max-x l-min-x l-max-y l-min-y)
@@ -644,7 +649,7 @@
 
 (defun calc-constraint-param-list-for-translational-sliding
   (mu-trans norm-axis slide-axis)
-   "Calc conatraint param list for translational sliding.
+  "Calc conatraint param list for translational sliding.
    mu-trans is friction coefficient.
    norm-axis is axis of normal (such as fz).
    slide-axis is axis of sliding direction (such as fx or fy)."
@@ -661,7 +666,8 @@
           ((< slide-sgn 0)
            (setf (elt (car ret) slide-idx) -1)
            (setf (elt (cadr ret) slide-idx) 1)))
-    ret))
+    (list :matrix ret :vector (list 0 0))
+    ))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/eus_qp/euslisp/contact-optimization.l
+++ b/eus_qp/euslisp/contact-optimization.l
@@ -421,6 +421,50 @@
    (send-super :init))
   )
 
+(defclass 2D-translational-sliding-contact-constraint
+  :super contact-constraint
+  :slots (mu-trans norm-axis slide-axis)
+  )
+
+(defmethod 2D-translational-sliding-contact-constraint
+  (:init
+   (tmp-mu-trans &key ((:norm-axis tmp-norm-axis) :fz) ((:slide-axis tmp-slide-axis) :x))
+   "Calc conatraint param list for translational sliding.
+   mu-trans is friction coefficient.
+   norm-axis is axis of normal (such as fz).
+   slide-axis is axis with sign of sliding direction (such as x, y, -x, or -y).
+   This constraint contains friction constraint for the other direction.
+   e.g. When slide-axis is :x, this cnstarint consists of sliding constraint of x and friction constraint of y."
+   (setq mu-trans tmp-mu-trans norm-axis tmp-norm-axis slide-axis tmp-slide-axis)
+   (setq constraint-param-list
+         (append (calc-constraint-param-list-for-translational-sliding
+                  mu-trans norm-axis slide-axis)
+                 (calc-constraint-param-list-for-translational-friction
+                  mu-trans norm-axis (sliding-axis->no-sliding-axis slide-axis))
+                 ))
+   (send-super :init))
+  (:gen-drawing-object
+   (&key (z-length 200))
+   (setq drawing-object
+         (make-prism
+          (cond
+           ((or (equal slide-axis :x) (equal slide-axis :-x))
+            (list
+             (float-vector 0 0 0)
+             (float-vector (* (axis->sgn slide-axis) mu-trans z-length) (* 1 mu-trans z-length) z-length)
+             (float-vector (* (axis->sgn slide-axis) mu-trans z-length) (* -1 mu-trans z-length) z-length))
+            )
+           ((or (equal slide-axis :y) (equal slide-axis :-y))
+            (list
+             (float-vector 0 0 0)
+             (float-vector (* 1 mu-trans z-length) (* (axis->sgn slide-axis) mu-trans z-length) z-length)
+             (float-vector (* -1 mu-trans z-length) (* (axis->sgn slide-axis) mu-trans z-length) z-length))
+            ))
+          1))
+   (send drawing-object :put :draw-on-args (list :color #f(1 1 0) :width 3))
+   )
+  )
+
 (defclass default-contact-constraint
   :super contact-constraint
   :slots ()
@@ -452,6 +496,27 @@
   (case ax
     (:fx 0) (:fy 1) (:fz 2)
     (:nx 3) (:ny 4) (:nz 5)
+    )
+  )
+
+(defun axis->index (ax)
+  (case ax
+    (:x 0) (:y 1) (:z 2)
+    (:-x 0) (:-y 1) (:-z 2)
+    )
+  )
+
+(defun axis->sgn (ax)
+  (case ax
+    (:x 1) (:y 1) (:z 1)
+    (:-x -1) (:-y -1) (:-z -1)
+    )
+  )
+
+(defun sliding-axis->no-sliding-axis (ax)
+  (case ax
+    (:x :fy) (:y :fx)
+    (:-x :fy) (:-y :fx)
     )
   )
 
@@ -576,6 +641,27 @@
            (setf (elt (cadr ret) moment-idx) 1)))))
     (list :matrix ret :vector (list 0 0))
     ))
+
+(defun calc-constraint-param-list-for-translational-sliding
+  (mu-trans norm-axis slide-axis)
+   "Calc conatraint param list for translational sliding.
+   mu-trans is friction coefficient.
+   norm-axis is axis of normal (such as fz).
+   slide-axis is axis of sliding direction (such as fx or fy)."
+  (let ((ret (mapcar #'(lambda (x) (make-list 6 :initial-element 0)) '(0 1)))
+        (norm-idx (force-axis->index norm-axis))
+        (slide-idx (axis->index slide-axis))
+        (slide-sgn (axis->sgn slide-axis))
+        )
+    (setf (elt (car ret) norm-idx) mu-trans)
+    (setf (elt (cadr ret) norm-idx) (- mu-trans))
+    (cond ((> slide-sgn 0)
+           (setf (elt (car ret) slide-idx) 1)
+           (setf (elt (cadr ret) slide-idx) -1))
+          ((< slide-sgn 0)
+           (setf (elt (car ret) slide-idx) -1)
+           (setf (elt (cadr ret) slide-idx) 1)))
+    ret))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/eus_qp/euslisp/test-contact-wrench-opt.l
+++ b/eus_qp/euslisp/test-contact-wrench-opt.l
@@ -410,10 +410,39 @@
    (list (send *cbox* :worldcoords) (send *cbox* :get :face-coords-2))
    ))
 
+(defun demo-cbox-wrench-calc-13
+  ()
+  "Demo for cbox wrench calculation by 2D-translational-sliding-contact-constraint. cbox is neutral pos rot. This sample is infeasible but it's correct."
+  (set-cbox-pose-neutral)
+  (not
+   (demo-cbox-wrench-calc-comon
+    (list (instance 2D-translational-sliding-contact-constraint :init 0.5 :slide-axis :x))
+    (list (send *cbox* :worldcoords))
+    )))
+
+(defun demo-cbox-wrench-calc-14
+  ()
+  "Demo for cbox wrench calculation by default-contact-constraint. cbox is neutral pos rot. cbox is sliding in the -y direction."
+  (set-cbox-pose-neutral)
+  (demo-cbox-wrench-calc-comon
+   (list (instance default-contact-constraint
+                   :init
+                   :mu-trans 0.5 :mu-rot 0.05
+                   :slide-axis :-y
+                   :l-min-x -150 :l-max-x 150
+                   :l-min-y -150 :l-max-y 150)
+         (instance default-contact-constraint
+                   :init
+                   :mu-trans 0.05 :mu-rot 0.05
+                   :l-min-x -50 :l-max-x 50
+                   :l-min-y -50 :l-max-y 50))
+   (list (send *cbox* :worldcoords) (send *cbox* :get :face-coords-2))
+   ))
+
 (defun demo-cbox-wrench-calc-all
   (&key (press-enter-p t))
   (let ((ret))
-    (dotimes (i 12)
+    (dotimes (i 14)
       (format t ";; demo-cbox-wrench-calc-~d~%" (1+ i))
       (push (funcall (eval (read-from-string (format nil "#'demo-cbox-wrench-calc-~d" (1+ i))))) ret)
       (when press-enter-p (format t ";; press enter~%") (read-line)))
@@ -422,7 +451,7 @@
 
 ;; Usage
 (warn ";; cbox demo functions~%")
-(dotimes (i 12)
+(dotimes (i 14)
   (warn ";;   (demo-cbox-wrench-calc-~d) ;; ~A~%" (1+ i)
         (documentation (read-from-string (format nil "demo-cbox-wrench-calc-~d" (1+ i))))))
 (warn ";;   (demo-cbox-wrench-calc-all) ;; for all tests~%")


### PR DESCRIPTION
摩擦力を受けながら並進方向に滑る場合の制約条件です．

```
(instance 2D-translational-sliding-contact-constraint :init 10 :norm-axis :z slide-axis :x)
```
とすると，x正方向に滑っている制約条件として，
摩擦係数10で，x負方向に最大摩擦力ちょうどの力がかかっている，y方向に最大摩擦以内の力がかかっている，ような制約条件ができます．

（内部向け：このPRは euslib/demo/murooka/fullbody_holding/contact-constraint-extension.l の一部を整理したものです．）
