### PR TITLE
[jsk_footstep_controller] Add odometry estimation based on leg kinematics

### DIFF
--- a/jsk_footstep_controller/CMakeLists.txt
+++ b/jsk_footstep_controller/CMakeLists.txt
@@ -10,6 +10,9 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   message_generation genmsg message_filters sensor_msgs geometry_msgs tf jsk_topic_tools
   eigen_conversions
+  kdl_parser
+  kdl_conversions
+  urdf
 )
 
 add_message_files(FILES
@@ -23,7 +26,7 @@ add_action_files(
   FILES LookAroundGround.action
 )
 generate_messages(
-  DEPENDENCIES actionlib_msgs std_msgs geometry_msgs)
+  DEPENDENCIES actionlib_msgs std_msgs geometry_msgs sensor_msgs)
 
 catkin_package(
 #  INCLUDE_DIRS include

--- a/jsk_footstep_controller/msg/SynchronizedForces.msg
+++ b/jsk_footstep_controller/msg/SynchronizedForces.msg
@@ -1,3 +1,5 @@
 Header header
 geometry_msgs/WrenchStamped lleg_force
 geometry_msgs/WrenchStamped rleg_force
+sensor_msgs/JointState joint_angles
+geometry_msgs/PointStamped zmp

--- a/jsk_footstep_controller/package.xml
+++ b/jsk_footstep_controller/package.xml
@@ -21,6 +21,9 @@
   <build_depend>tf</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>jsk_topic_tools</build_depend>
+  <build_depend>kdl_parser</build_depend>
+  <build_depend>urdf</build_depend>
+  <build_depend>kdl_conversions</build_depend>
   <run_depend>jsk_footstep_msgs</run_depend>
   <run_depend>jsk_footstep_planner</run_depend>
   <run_depend>message_generation</run_depend>
@@ -39,12 +42,9 @@
   <run_depend>tf_conversions</run_depend>
   <build_depend>std_msgs</build_depend>
   <run_depend>std_msgs</run_depend>
-  <!-- The export tag contains other, unspecified, tags -->
+  <run_depend>kdl_parser</run_depend>
+  <run_depend>urdf</run_depend>
+  <run_depend>kdl_conversions</run_depend>
   <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
-    <!-- Other tools can request additional information be placed here -->
-
   </export>
 </package>


### PR DESCRIPTION
Three types of naive algorithm are implemented:
1) Estimate support leg from force sensors and keep support leg during double stance phase
2) Estimate support leg from force sensors and change support leg during double stance phase by leg forces
3) Estimate support leg from force sensors and change support leg during double stance phase by zmp

These naive algorithms are not so good.
for example, walk JAXON in the current spot with 16 steps and it estimates as 20mm forward but it actually moves 64mm forward.