### PR TITLE
[jsk_footstep_planner] Re-implement footstepHeuristicStepCost in     computationally-efficient way.

### DIFF
--- a/jsk_footstep_planner/CMakeLists.txt
+++ b/jsk_footstep_planner/CMakeLists.txt
@@ -17,6 +17,7 @@ catkin_package(
   )
 
 add_definitions("-g -O2")
+
 include_directories(include ${catkin_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS})
 link_libraries(${pcl_ros_LIBRARIES} ${catkin_LIBRARIES})
 add_library(jsk_footstep_planner
@@ -35,6 +36,8 @@ add_executable(footstep_planning_2d_interactive_demo demo/footstep_planning_2d_i
 target_link_libraries(footstep_planning_2d_interactive_demo jsk_footstep_planner)
 add_executable(footstep_planning_2d_perception_demo demo/footstep_planning_2d_perception_demo.cpp)
 target_link_libraries(footstep_planning_2d_perception_demo jsk_footstep_planner)
+add_executable(bench_footstep_planning_without_perception bench/bench_footstep_planning_without_perception.cpp)
+target_link_libraries(bench_footstep_planning_without_perception jsk_footstep_planner)
 
 add_executable(footstep_projection_demo demo/footstep_projection_demo.cpp)
 target_link_libraries(footstep_projection_demo jsk_footstep_planner)
@@ -48,6 +51,7 @@ install(TARGETS jsk_footstep_planner sample_astar sample_simple_graph
   footstep_planning_2d_demo footstep_planning_2d_interactive_demo
   footstep_planning_2d_perception_demo
   footstep_projection_demo
+  bench_footstep_planning_without_perception
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/jsk_footstep_planner/CMakeLists.txt
+++ b/jsk_footstep_planner/CMakeLists.txt
@@ -17,6 +17,10 @@ catkin_package(
   )
 
 add_definitions("-g -O2")
+find_package(OpenMP)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS})
 link_libraries(${pcl_ros_LIBRARIES} ${catkin_LIBRARIES})
@@ -38,6 +42,8 @@ add_executable(footstep_planning_2d_perception_demo demo/footstep_planning_2d_pe
 target_link_libraries(footstep_planning_2d_perception_demo jsk_footstep_planner)
 add_executable(bench_footstep_planning_without_perception bench/bench_footstep_planning_without_perception.cpp)
 target_link_libraries(bench_footstep_planning_without_perception jsk_footstep_planner)
+add_executable(bench_footstep_planning_with_perception bench/bench_footstep_planning_with_perception.cpp)
+target_link_libraries(bench_footstep_planning_with_perception jsk_footstep_planner)
 
 add_executable(footstep_projection_demo demo/footstep_projection_demo.cpp)
 target_link_libraries(footstep_projection_demo jsk_footstep_planner)

--- a/jsk_footstep_planner/bench/bench_footstep_planning_with_perception.cpp
+++ b/jsk_footstep_planner/bench/bench_footstep_planning_with_perception.cpp
@@ -37,9 +37,26 @@
 #include <time.h>
 #include <boost/random.hpp>
 #include <fstream>
+
 using namespace jsk_footstep_planner;
 
 const Eigen::Vector3f footstep_size(0.2, 0.1, 0.000001);
+pcl::PointCloud<pcl::PointNormal>::Ptr
+generateCloudFlat()
+{
+  pcl::PointCloud<pcl::PointNormal>::Ptr gen_cloud(new pcl::PointCloud<pcl::PointNormal>);
+  for (double y = -5; y < 5; y = y + 0.01) {
+    for (double x = -5; x < 5; x = x + 0.01) {
+      pcl::PointNormal p;
+      p.x = x;
+      p.y = y;
+      gen_cloud->points.push_back(p);
+    }
+  }
+  return gen_cloud;
+}
+
+
 
 void setupGraph(FootstepGraph::Ptr graph)
 {
@@ -71,17 +88,21 @@ void setupGraph(FootstepGraph::Ptr graph)
 
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "bench_footstep_planning_without_perception");
+  ros::init(argc, argv, "bench_footstep_planning_with_perception");
   ros::NodeHandle nh("~");
+  //graph->setProgressPublisher(nh, "progress");
+  // set successors
   const size_t trials = 10;
   const double dx = 0.2;
   for (size_t ti = 0; ti < 8; ti++) {
-    FootstepGraph::Ptr graph(new FootstepGraph(resolution));
+    pcl::PointCloud<pcl::PointNormal>::Ptr cloud = generateCloudFlat();
+    FootstepGraph::Ptr graph(new FootstepGraph(resolution, true, true));
+    graph->setPointCloudModel(cloud);
     setupGraph(graph);
     double theta = 2.0 * M_PI / 8 * ti ;
-    std::ofstream ofs((boost::format("footstep_planning_without_perception-%f.csv") % theta).str().c_str());
-    for (double x = -3; x <= 3.0; x += 0.2) {
-      for (double y = -3; y <= 3.0; y += 0.2) {
+    std::ofstream ofs((boost::format("footstep_planning_with_perception-%f.csv") % theta).str().c_str());
+    for (double x = -3; x <= 3.0; x += dx) {
+      for (double y = -3; y <= 3.0; y += dx) {
         std::cout << x << ", " << y << ", " << theta << std::endl;
         ros::WallTime start = ros::WallTime::now();
         for (size_t i = 0; i < trials; i++) {

--- a/jsk_footstep_planner/bench/bench_footstep_planning_without_perception.cpp
+++ b/jsk_footstep_planner/bench/bench_footstep_planning_without_perception.cpp
@@ -1,0 +1,138 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+#include <jsk_footstep_msgs/FootstepArray.h>
+#include "jsk_footstep_planner/footstep_graph.h"
+#include "jsk_footstep_planner/astar_solver.h"
+#include "jsk_footstep_planner/footstep_astar_solver.h"
+#include <time.h>
+#include <boost/random.hpp>
+#include <fstream>
+using namespace jsk_footstep_planner;
+
+const Eigen::Vector3f footstep_size(0.2, 0.1, 0.000001);
+const Eigen::Vector3f resolution(0.05, 0.05, 0.08);
+
+Eigen::Affine3f affineFromXYYaw(double x, double y, double yaw)
+{
+  return Eigen::Translation3f(x, y, 0) * Eigen::AngleAxisf(yaw, Eigen::Vector3f::UnitZ());
+}
+
+void plan(double x, double y, double yaw,
+          FootstepGraph::Ptr graph, ros::Publisher& pub_path,
+          ros::Publisher& pub_goal,
+          Eigen::Vector3f footstep_size)
+{
+  Eigen::Affine3f goal_center = affineFromXYYaw(x, y, yaw);
+  FootstepState::Ptr left_goal(new FootstepState(jsk_footstep_msgs::Footstep::LEFT,
+                                                 goal_center * Eigen::Translation3f(0, 0.1, 0),
+                                                 footstep_size,
+                                                 resolution));
+  FootstepState::Ptr right_goal(new FootstepState(jsk_footstep_msgs::Footstep::RIGHT,
+                                                  goal_center * Eigen::Translation3f(0, -0.1, 0),
+                                                  footstep_size,
+                                                  resolution));
+  graph->setGoalState(left_goal, right_goal);
+  //AStarSolver<FootstepGraph> solver(graph);
+  FootstepAStarSolver<FootstepGraph> solver(graph, 100, 100, 100);
+  solver.setHeuristic(&footstepHeuristicStepCost);
+  std::vector<SolverNode<FootstepState, FootstepGraph>::Ptr> path = solver.solve();
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "foootstep_planning_2d");
+  ros::NodeHandle nh("~");
+  ros::Publisher pub_start = nh.advertise<jsk_footstep_msgs::FootstepArray>("start", 1, true);
+  ros::Publisher pub_goal = nh.advertise<jsk_footstep_msgs::FootstepArray>("goal", 1, true);
+  ros::Publisher pub_path = nh.advertise<jsk_footstep_msgs::FootstepArray>("path", 1, true);
+  boost::mt19937 rng( static_cast<unsigned long>(time(0)) );
+  boost::uniform_real<> xyrange(-3.0,3.0);
+  boost::variate_generator< boost::mt19937, boost::uniform_real<> > pos_rand(rng, xyrange);
+  boost::uniform_real<> trange(0, 2 * M_PI);
+  boost::variate_generator< boost::mt19937, boost::uniform_real<> > rot_rand(rng, trange);
+
+  FootstepGraph::Ptr graph(new FootstepGraph(resolution));
+  //graph->setProgressPublisher(nh, "progress");
+  // set successors
+  std::vector<Eigen::Affine3f> successors;
+  successors.push_back(affineFromXYYaw(0, -0.2, 0));
+  successors.push_back(affineFromXYYaw(0, -0.3, 0));
+  successors.push_back(affineFromXYYaw(0, -0.15, 0));
+  successors.push_back(affineFromXYYaw(0.2, -0.2, 0));
+  successors.push_back(affineFromXYYaw(0.25, -0.2, 0));
+  successors.push_back(affineFromXYYaw(0.1, -0.2, 0));
+  successors.push_back(affineFromXYYaw(-0.1, -0.2, 0));
+  successors.push_back(affineFromXYYaw(0, -0.2, 0.17));
+  successors.push_back(affineFromXYYaw(0, -0.3, 0.17));
+  successors.push_back(affineFromXYYaw(0.2, -0.2, 0.17));
+  successors.push_back(affineFromXYYaw(0.25, -0.2, 0.17));
+  successors.push_back(affineFromXYYaw(0.1, -0.2, 0.17));
+  successors.push_back(affineFromXYYaw(0, -0.2, -0.17));
+  successors.push_back(affineFromXYYaw(0, -0.3, -0.17));
+  successors.push_back(affineFromXYYaw(0.2, -0.2, -0.17));
+  successors.push_back(affineFromXYYaw(0.25, -0.2, -0.17));
+  successors.push_back(affineFromXYYaw(0.1, -0.2, -0.17));
+  FootstepState::Ptr start(new FootstepState(jsk_footstep_msgs::Footstep::LEFT,
+                                             Eigen::Affine3f::Identity(),
+                                             footstep_size,
+                                             resolution));
+  graph->setStartState(start);
+  graph->setBasicSuccessors(successors);
+
+  
+  const size_t trials = 10;
+  for (size_t ti = 0; ti < 8; ti++) {
+    double theta = 2.0 * M_PI / 8 * ti ;
+  //for (double theta = 0; theta <= 2.0 * M_PI; theta += M_PI / 4.0) {
+    std::ofstream ofs((boost::format("footstep_planning_without_perception-%f.csv") % theta).str().c_str());
+    for (double x = -3; x <= 3.0; x += 0.1) {
+      for (double y = -3; y <= 3.0; y += 0.1) {
+        std::cout << x << ", " << y << ", " << theta << std::endl;
+        ros::WallTime start = ros::WallTime::now();
+        for (size_t i = 0; i < trials; i++) {
+          plan(x, y, theta, graph, pub_path, pub_goal, footstep_size);
+        }
+        ros::WallTime end = ros::WallTime::now();
+        double time_to_solev = (end - start).toSec() / trials;
+        ofs << (boost::format("%f,%f,%f,%f") % x % y % theta %  time_to_solev).str() << std::endl;
+      }
+      ofs << std::endl;
+    }
+  }
+  std::cout << "Plot result by gnuplot:" << std::endl;
+  std::cout << "  set pm3d map" << std::endl;
+  std::cout << "  splot output.csv u 2:1:4" << std::endl;
+  return 0;
+}

--- a/jsk_footstep_planner/bench/bench_util.h
+++ b/jsk_footstep_planner/bench/bench_util.h
@@ -1,0 +1,65 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "jsk_footstep_planner/footstep_graph.h"
+#include "jsk_footstep_planner/astar_solver.h"
+#include "jsk_footstep_planner/footstep_astar_solver.h"
+
+using namespace jsk_footstep_planner;
+const Eigen::Vector3f resolution(0.05, 0.05, 0.08);
+inline Eigen::Affine3f affineFromXYYaw(double x, double y, double yaw)
+{
+  return Eigen::Translation3f(x, y, 0) * Eigen::AngleAxisf(yaw, Eigen::Vector3f::UnitZ());
+}
+
+inline void plan(double x, double y, double yaw,
+          FootstepGraph::Ptr graph,
+          Eigen::Vector3f footstep_size)
+{
+  Eigen::Affine3f goal_center = affineFromXYYaw(x, y, yaw);
+  FootstepState::Ptr left_goal(new FootstepState(jsk_footstep_msgs::Footstep::LEFT,
+                                                 goal_center * Eigen::Translation3f(0, 0.1, 0),
+                                                 footstep_size,
+                                                 resolution));
+  FootstepState::Ptr right_goal(new FootstepState(jsk_footstep_msgs::Footstep::RIGHT,
+                                                  goal_center * Eigen::Translation3f(0, -0.1, 0),
+                                                  footstep_size,
+                                                  resolution));
+  graph->setGoalState(left_goal, right_goal);
+  //AStarSolver<FootstepGraph> solver(graph);
+  FootstepAStarSolver<FootstepGraph> solver(graph, 100, 100, 100);
+  solver.setHeuristic(&footstepHeuristicStepCost);
+  std::vector<SolverNode<FootstepState, FootstepGraph>::Ptr> path = solver.solve();
+}

--- a/jsk_footstep_planner/demo/footstep_planning_2d_interactive_demo.cpp
+++ b/jsk_footstep_planner/demo/footstep_planning_2d_interactive_demo.cpp
@@ -55,6 +55,12 @@ Eigen::Affine3f affineFromXYYaw(double x, double y, double yaw)
   return Eigen::Translation3f(x, y, 0) * Eigen::AngleAxisf(yaw, Eigen::Vector3f::UnitZ());
 }
 
+void profile(FootstepAStarSolver<FootstepGraph>& solver, FootstepGraph::Ptr graph)
+{
+  ROS_INFO("open list: %lu", solver.getOpenList().size());
+  ROS_INFO("close list: %lu", solver.getCloseList().size());
+}
+
 void plan(const Eigen::Affine3f& goal_center,
           FootstepGraph::Ptr graph, ros::Publisher& pub_path,
           ros::Publisher& pub_goal,
@@ -82,6 +88,7 @@ void plan(const Eigen::Affine3f& goal_center,
   //solver.setHeuristic(&footstepHeuristicStraight);
   //solver.setHeuristic(&footstepHeuristicStraightRotation);
   solver.setHeuristic(&footstepHeuristicStepCost);
+  solver.setProfileFunction(&profile);
   ros::WallTime start_time = ros::WallTime::now();
   std::vector<SolverNode<FootstepState, FootstepGraph>::Ptr> path = solver.solve();
   ros::WallTime end_time = ros::WallTime::now();

--- a/jsk_footstep_planner/demo/footstep_planning_2d_perception_demo.cpp
+++ b/jsk_footstep_planner/demo/footstep_planning_2d_perception_demo.cpp
@@ -177,7 +177,7 @@ generateCloudFlat()
 pcl::PointCloud<pcl::PointNormal>::Ptr
 generateCloudHills()
 {
-  const double height = 0.3;
+  const double height = 0.1;
   pcl::PointCloud<pcl::PointNormal>::Ptr gen_cloud(new pcl::PointCloud<pcl::PointNormal>);
   for (double y = -2; y < 2; y = y + 0.01) {
     for (double x = -2; x < 2; x = x + 0.01) {

--- a/jsk_footstep_planner/include/jsk_footstep_planner/best_first_search_solver.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/best_first_search_solver.h
@@ -51,7 +51,9 @@ namespace jsk_footstep_planner
     typedef typename GraphT::StateT State;
     typedef typename GraphT::Ptr GraphPtr;
     typedef typename SolverNode<State, GraphT>::Ptr SolverNodePtr;
-    
+    typedef typename std::priority_queue<SolverNodePtr,
+                                         std::vector<SolverNodePtr>,
+                                         std::greater<SolverNodePtr> > OpenList;
     BestFirstSearchSolver(GraphPtr graph): Solver<GraphT>(graph) {}
     
     virtual void addToOpenList(SolverNodePtr node)
@@ -77,7 +79,7 @@ namespace jsk_footstep_planner
     }
     
   protected:
-    std::priority_queue<SolverNodePtr, std::vector<SolverNodePtr>, std::greater<SolverNodePtr> > open_list_;
+    OpenList open_list_;
   private:
     
   };

--- a/jsk_footstep_planner/include/jsk_footstep_planner/footstep_state_discrete_close_list.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/footstep_state_discrete_close_list.h
@@ -62,9 +62,15 @@ namespace jsk_footstep_planner
       int x = state->indexX();
       int y = state->indexY();
       int theta = state->indexT();
+      if (!data_[x - x_offset_][y - y_offset_][theta - theta_offset_]) {
+        size_++;
+      }
       data_[x - x_offset_][y - y_offset_][theta - theta_offset_] = state;
     }
+
+    inline size_t size() { return size_; }
   protected:
+    size_t size_;
     const size_t x_num_;
     const size_t y_num_;
     const size_t theta_num_;
@@ -108,6 +114,15 @@ namespace jsk_footstep_planner
       return boost::make_tuple(kx, ky, kt);
     }
 
+    inline size_t size()
+    {
+      std::map<VolumeKey, FootstepStateDiscreteCloseListLocal::Ptr>::iterator it;
+      size_t s = 0;
+      for (it = local_volumes_.begin(); it != local_volumes_.end(); ++it) {
+        s += it->second->size();
+      }
+      return s;
+    }
     
     inline void push_back(FootstepState::Ptr state)
     {

--- a/jsk_footstep_planner/scripts/plot_bench.py
+++ b/jsk_footstep_planner/scripts/plot_bench.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+import matplotlib.pyplot as plt
+import numpy as np
+import csv
+import sys
+from itertools import chain
+from math import pi
+# from the docs:
+
+# If interpolation is None, default to rc image.interpolation. See also
+# the filternorm and filterrad parameters. If interpolation is 'none', then
+# no interpolation is performed on the Agg, ps and pdf backends. Other
+# backends will fall back to 'nearest'.
+#
+# http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.imshow
+csv_files = sys.argv[1:]
+# methods = [None, 'none', 'nearest', 'bilinear', 'bicubic', 'spline16',
+#            'spline36', 'hanning', 'hamming', 'hermite', 'kaiser', 'quadric',
+#            'catrom', 'gaussian', 'bessel', 'mitchell', 'sinc', 'lanczos']
+methods = ['none']
+# grid = np.random.rand(4, 4)
+
+# fig, axes = plt.subplots(3, 6, figsize=(12, 6),
+#                          subplot_kw={'xticks': [], 'yticks': []})
+
+dx = 3
+dy = 3
+
+def plot(csv_file, ax):
+    global im
+    reader = csv.reader(open(csv_file))
+    xs = []
+    ys = []
+    ts = []
+    zs = dict()
+    
+    for row in reader:
+        if row:
+            x = float(row[0])
+            y = float(row[1])
+            theta = float(row[2])
+            z = float(row[3])
+            if x not in xs:
+                xs.append(x)
+            if y not in ys:
+                ys.append(y)
+            zs[(x, y)] = z
+    xs.sort()
+    ys.sort()
+
+    minz = 0
+    maxz = 0.2
+
+    img = np.arange(0, len(xs) * len(ys), 1.0).reshape((len(xs), len(ys)))
+    for x, i in zip(xs, range(len(xs))):
+        for y, j in zip(ys, range(len(ys))):
+            z = zs[(x, y)]
+            img[j][i] = z
+    #im = ax.pcolor(img, vmin=minz, vmax=maxz, cmap="gnuplot")
+    im = ax.imshow(img, vmin=minz, vmax=maxz, cmap="gnuplot")
+    ax.set_xticklabels(np.arange(-dx - 1, dx+1))
+    ax.set_yticklabels(np.arange(-dy - 1, dy+1))
+    ax.set_xlabel("x [m]")
+    ax.set_ylabel("y [m]")
+    ax.set_title('$\\theta$ = %f deg' % (theta / pi * 180.0))
+
+
+if len(csv_files) % 3 == 0:
+    xnum = len(csv_files) / 3
+else:
+    xnum = len(csv_files) / 3 + 1
+
+fig, axes = plt.subplots(xnum, 3)
+for csv_file, ax in zip(csv_files, axes.flat):
+    plot(csv_file, ax)
+for a in axes.flat[len(csv_files):]:
+    fig.delaxes(a)
+plt.tight_layout()
+fig.subplots_adjust(right = 0.8)
+cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])
+cb = fig.colorbar(im, cax=cbar_ax)
+cb.set_label("Time [sec]")
+plt.show()

--- a/jsk_footstep_planner/src/footstep_state_discrete_close_list.cpp
+++ b/jsk_footstep_planner/src/footstep_state_discrete_close_list.cpp
@@ -41,7 +41,8 @@ namespace jsk_footstep_planner
     int x_offset, int y_offset, int theta_offset,
     size_t x_num, size_t y_num, size_t theta_num):
     x_num_(x_num), y_num_(y_num), theta_num_(theta_num),
-    x_offset_(x_offset), y_offset_(y_offset), theta_offset_(theta_offset)
+    x_offset_(x_offset), y_offset_(y_offset), theta_offset_(theta_offset),
+    size_(0)
   {
     // initialize data_
     data_ = std::vector<std::vector<std::vector<FootstepState::Ptr> > >(x_num_);


### PR DESCRIPTION
1. Do not use Eigen::Affine3f::rotation because it calls SVD internally.
2. Do not cast to Eigen::AngleAxisf, just use cos(w/2) to compute angle
from quaternion.

1 is important because our planner is 10 times faster than before.

