### PR TITLE
[jsk_footstep_planner] Add ~hole_rate to simulate hole in pointcloud

### DIFF
--- a/jsk_footstep_planner/cfg/PointCloudModelGenerator.cfg
+++ b/jsk_footstep_planner/cfg/PointCloudModelGenerator.cfg
@@ -19,4 +19,5 @@ model_enum = gen.enum([gen.const("flat", str_t, "flat", "flat"),
                        gen.const("stairs", str_t, "stairs", "stairs")],
                       "model")
 gen.add("model", str_t, 0, "", "flat", edit_method=model_enum)
+gen.add("hole_rate", double_t, 0, "", 0.0, 0.0, 100.0)
 exit (gen.generate (PACKAGE, "jsk_footstep_planner", "PointCloudModelGenerator"))

--- a/jsk_footstep_planner/include/jsk_footstep_planner/pointcloud_model_generator.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/pointcloud_model_generator.h
@@ -55,11 +55,15 @@ namespace jsk_footstep_planner
     typedef boost::shared_ptr<PointCloudModelGenerator> Ptr;
     typedef pcl::PointNormal PointT;
     virtual void generate(const std::string& model_name,
-                          pcl::PointCloud<PointT>& output);
+                          pcl::PointCloud<PointT>& output,
+                          double hole_rate = 0.0);
   protected:
-    virtual void flat(pcl::PointCloud<PointT>& output);
-    virtual void stairs(pcl::PointCloud<PointT>& output);
-    virtual void hills(pcl::PointCloud<PointT>& output);
+    virtual void flat(pcl::PointCloud<PointT>& output,
+                      double hole_rate);
+    virtual void stairs(pcl::PointCloud<PointT>& output,
+                        double hole_rate);
+    virtual void hills(pcl::PointCloud<PointT>& output,
+                       double hole_rate);
   private:
     
   };

--- a/jsk_footstep_planner/src/pointcloud_model_generator.cpp
+++ b/jsk_footstep_planner/src/pointcloud_model_generator.cpp
@@ -34,67 +34,95 @@
  *********************************************************************/
 
 #include "jsk_footstep_planner/pointcloud_model_generator.h"
+#include <boost/random.hpp>
 
 namespace jsk_footstep_planner
 {
   void PointCloudModelGenerator::generate(
     const std::string& model_name,
-    pcl::PointCloud<PointT>& output)
+    pcl::PointCloud<PointT>& output,
+    double hole_rate)
   {
     output.points.clear();
     if (model_name == "flat") {
-      flat(output);
+      flat(output, hole_rate);
     }
     else if (model_name == "stairs") {
-      stairs(output);
+      stairs(output, hole_rate);
     }
     else if (model_name == "hills") {
-      hills(output);
+      hills(output, hole_rate);
     }
   }
 
-  void PointCloudModelGenerator::flat(pcl::PointCloud<PointT>& output)
+  void PointCloudModelGenerator::flat(pcl::PointCloud<PointT>& output, double hole_rate)
   {
+    boost::mt19937 gen( static_cast<unsigned long>(time(0)) );
+    boost::uniform_real<> dst( 0, 100 );
+    boost::variate_generator<
+      boost::mt19937&, boost::uniform_real<>
+      > rand( gen, dst );
+
     for (double y = -2; y < 2; y = y + 0.01) {
       for (double x = -2; x < 2; x = x + 0.01) {
-        pcl::PointNormal p;
-        p.x = x;
-        p.y = y;
-        output.points.push_back(p);
+        if (rand() >= hole_rate) {
+          pcl::PointNormal p;
+          p.x = x;
+          p.y = y;
+          output.points.push_back(p);
+        }
       }
     }
   }
 
-  void PointCloudModelGenerator::hills(pcl::PointCloud<PointT>& output)
+  void PointCloudModelGenerator::hills(pcl::PointCloud<PointT>& output, double hole_rate)
   {
+    boost::mt19937 gen( static_cast<unsigned long>(time(0)) );
+    boost::uniform_real<> dst( 0, 100 );
+    boost::variate_generator<
+      boost::mt19937&, boost::uniform_real<>
+      > rand( gen, dst );
+
     const double height = 0.1;
     for (double y = -2; y < 2; y = y + 0.01) {
       for (double x = -2; x < 2; x = x + 0.01) {
-        pcl::PointNormal p;
-        p.x = x;
-        p.y = y;
-        p.z = height * sin(x * 2) * sin(y * 2);
-        output.points.push_back(p);
+        if (rand() >= hole_rate) {
+          pcl::PointNormal p;
+          p.x = x;
+          p.y = y;
+          p.z = height * sin(x * 2) * sin(y * 2);
+          output.points.push_back(p);
+        }
       }
     }
   }
 
-  void PointCloudModelGenerator::stairs(pcl::PointCloud<PointT>& output)
+  void PointCloudModelGenerator::stairs(pcl::PointCloud<PointT>& output, double hole_rate)
   {
+    boost::mt19937 gen( static_cast<unsigned long>(time(0)) );
+    boost::uniform_real<> dst( 0, 100 );
+    boost::variate_generator<
+      boost::mt19937&, boost::uniform_real<>
+      > rand( gen, dst );
+
     for (double y = -2; y < 2; y = y + 0.01) {
       for (double x = -1; x < 0; x = x + 0.01) {
-        pcl::PointNormal p;
-        p.x = x;
-        p.y = y;
-        p.z = 0;
-        output.points.push_back(p);
+        if (rand() >= hole_rate) {
+          pcl::PointNormal p;
+          p.x = x;
+          p.y = y;
+          p.z = 0;
+          output.points.push_back(p);
+        }
       }
       for (double x = 0; x < 5; x = x + 0.01) {
-        pcl::PointNormal p;
-        p.x = x;
-        p.y = y;
-        p.z = floor(x * 4) * 0.1;
-        output.points.push_back(p);
+        if (rand() >= hole_rate) {
+          pcl::PointNormal p;
+          p.x = x;
+          p.y = y;
+          p.z = floor(x * 4) * 0.1;
+          output.points.push_back(p);
+        }
       }
     }
   }

--- a/jsk_footstep_planner/src/pointcloud_model_generator_node.cpp
+++ b/jsk_footstep_planner/src/pointcloud_model_generator_node.cpp
@@ -41,16 +41,14 @@
 
 using namespace jsk_footstep_planner;
 
-ros::Publisher pub_cloud;
-sensor_msgs::PointCloud2 ros_cloud;
+double hole_rate;
+std::string model;
+boost::mutex mutex;
 void reconfigureCallback(PointCloudModelGeneratorConfig &config, uint32_t level)
 {
-  PointCloudModelGenerator gen;
-  pcl::PointCloud<pcl::PointNormal> cloud;
-  gen.generate(config.model, cloud);
-  pcl::toROSMsg(cloud, ros_cloud);
-  ros_cloud.header.frame_id = "odom";
-  ros_cloud.header.stamp = ros::Time::now();
+  boost::mutex::scoped_lock lock(mutex);
+  hole_rate = config.hole_rate;
+  model = config.model;
 }
 
 
@@ -59,13 +57,23 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "pointcloud_model_generator_node");
   ros::NodeHandle pnh("~");
   ros::Rate r(1);
-  pub_cloud = pnh.advertise<sensor_msgs::PointCloud2>("output", 1, true);
+  ros::Publisher pub_cloud = pnh.advertise<sensor_msgs::PointCloud2>("output", 1, true);
   dynamic_reconfigure::Server<PointCloudModelGeneratorConfig> server;
   server.setCallback(boost::bind(&reconfigureCallback, _1, _2));
   while (ros::ok()) {
     ros::spinOnce();
     r.sleep();
-    pub_cloud.publish(ros_cloud);
+    {
+      boost::mutex::scoped_lock lock(mutex);
+      PointCloudModelGenerator gen;
+      pcl::PointCloud<pcl::PointNormal> cloud;
+      gen.generate(model, cloud, hole_rate);
+      sensor_msgs::PointCloud2 ros_cloud;
+      pcl::toROSMsg(cloud, ros_cloud);
+      ros_cloud.header.frame_id = "odom";
+      ros_cloud.header.stamp = ros::Time::now();
+      pub_cloud.publish(ros_cloud);
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Left is a pointcloud with ~hole_rate=40.0 in height map representation and
right one is noise-reduced height map by morphological filtering.

![screenshot_from_2015-07-28 03 58 31](https://cloud.githubusercontent.com/assets/40454/8914938/ee845b7a-34dc-11e5-9530-16894034648f.png)
