### PR TITLE
[jsk_footstep_controller/footcoords] Publish zmp as tf for visualization

### DIFF
--- a/jsk_footstep_controller/include/jsk_footstep_controller/footcoords.h
+++ b/jsk_footstep_controller/include/jsk_footstep_controller/footcoords.h
@@ -168,7 +168,6 @@ namespace jsk_footstep_controller
     virtual void getRollPitch(const Eigen::Affine3d& pose, float& roll, float& pitch);
     // ros variables
     boost::mutex mutex_;
-    Eigen::Vector3d latest_zmp_point_;
     Eigen::Affine3d odom_pose_;
     Eigen::Affine3d odom_init_pose_;
     ros::Timer periodic_update_timer_;

--- a/jsk_footstep_controller/include/jsk_footstep_controller/footcoords.h
+++ b/jsk_footstep_controller/include/jsk_footstep_controller/footcoords.h
@@ -168,6 +168,7 @@ namespace jsk_footstep_controller
     virtual void getRollPitch(const Eigen::Affine3d& pose, float& roll, float& pitch);
     // ros variables
     boost::mutex mutex_;
+    Eigen::Vector3d latest_zmp_point_;
     Eigen::Affine3d odom_pose_;
     Eigen::Affine3d odom_init_pose_;
     ros::Timer periodic_update_timer_;
@@ -197,6 +198,7 @@ namespace jsk_footstep_controller
     boost::shared_ptr<tf::TransformListener> tf_listener_;
     tf::TransformBroadcaster tf_broadcaster_;
     // parameters
+    std::string zmp_frame_id_;
     std::string output_frame_id_;
     std::string parent_frame_id_;
     std::string midcoords_frame_id_;

--- a/jsk_footstep_controller/src/footcoords.cpp
+++ b/jsk_footstep_controller/src/footcoords.cpp
@@ -69,6 +69,9 @@ namespace jsk_footstep_controller
     pnh.param("sampling_time_", sampling_time_, 0.2);
     pnh.param("output_frame_id", output_frame_id_,
               std::string("odom_on_ground"));
+    pnh.param("zmp_frame_id", zmp_frame_id_,
+              std::string("zmp"));
+
     pnh.param("parent_frame_id", parent_frame_id_, std::string("odom"));
     pnh.param("midcoords_frame_id", midcoords_frame_id_, std::string("ground"));
     pnh.param("root_frame_id", root_frame_id_, std::string("BODY"));
@@ -291,6 +294,13 @@ namespace jsk_footstep_controller
     forces.joint_angles = *joint_states;
     forces.zmp = *zmp;
     pub_synchronized_forces_.publish(forces);
+    {
+      boost::mutex::scoped_lock lock(mutex_);
+      // Just for visualization
+      if (zmp->point.z < 0) {
+        tf::pointMsgToEigen(zmp->point, latest_zmp_point_);
+      }
+    }
   }
 
   void Footcoords::updateChain(std::map<std::string, double>& joint_angles,
@@ -923,7 +933,8 @@ namespace jsk_footstep_controller
     // publish midcoords_ and ground_cooords_
     geometry_msgs::TransformStamped ros_midcoords, 
       ros_ground_coords, ros_odom_to_body_coords,
-      ros_body_on_odom_coords, ros_odom_init_coords;
+      ros_body_on_odom_coords, ros_odom_init_coords,
+      ros_zmp_coords;
     // ros_midcoords: ROOT -> ground
     // ros_ground_coords: odom -> odom_on_ground = identity
     // ros_odom_root_coords: odom -> odom_root = identity
@@ -946,6 +957,9 @@ namespace jsk_footstep_controller
     ros_odom_init_coords.header.stamp = stamp;
     ros_odom_init_coords.header.frame_id = parent_frame_id_;
     ros_odom_init_coords.child_frame_id = odom_init_frame_id_;
+    ros_zmp_coords.header.stamp = stamp;
+    ros_zmp_coords.header.frame_id = root_frame_id_;
+    ros_zmp_coords.child_frame_id = zmp_frame_id_;
     Eigen::Affine3d identity = Eigen::Affine3d::Identity();
     float roll, pitch;
     getRollPitch(odom_pose_, roll, pitch);
@@ -959,17 +973,20 @@ namespace jsk_footstep_controller
                                                            odom_init_pose_.translation()[1],
                                                            0.0) * 
                                       Eigen::AngleAxisd(getYaw(odom_init_pose_), Eigen::Vector3d::UnitZ()));
+    Eigen::Affine3d zmp_pose = Eigen::Affine3d::Identity() * Eigen::Translation3d(latest_zmp_point_);
     tf::transformTFToMsg(midcoords_, ros_midcoords.transform);
     tf::transformEigenToMsg(identity, ros_ground_coords.transform);
     tf::transformEigenToMsg(body_on_odom_pose.inverse(), ros_body_on_odom_coords.transform);
     tf::transformEigenToMsg(odom_pose_, ros_odom_to_body_coords.transform);
     tf::transformEigenToMsg(odom_init_pose, ros_odom_init_coords.transform);
+    tf::transformEigenToMsg(zmp_pose, ros_zmp_coords.transform);
     std::vector<geometry_msgs::TransformStamped> tf_transforms;
     tf_transforms.push_back(ros_midcoords);
     tf_transforms.push_back(ros_ground_coords);
     tf_transforms.push_back(ros_odom_to_body_coords);
     tf_transforms.push_back(ros_body_on_odom_coords);
     tf_transforms.push_back(ros_odom_init_coords);
+    tf_transforms.push_back(ros_zmp_coords);
     tf_broadcaster_.sendTransform(tf_transforms);
   }
 


### PR DESCRIPTION
DO NOT USE THIS FRAME FOR PERCEPTION AND PLANNING because the timestamp is not reliable
It's just for visualization.

You can visualize trajectory of zmp by jsk_rviz_plugins/TFTrajectory on rviz.
![screenshot_from_2015-08-07 15 14 02](https://cloud.githubusercontent.com/assets/40454/9129784/015df0e8-3d17-11e5-9f5c-73115ab23b51.png)

movie only for jsk members
https://drive.google.com/a/jsk.imi.i.u-tokyo.ac.jp/file/d/0B4bnoIcbRJVuY09XYjNMY2ZjemM/view?usp=sharing