### PR TITLE
use ftol xtol values in coresolver initialization

### DIFF
--- a/eus_nlopt/euslisp/nlopt.l
+++ b/eus_nlopt/euslisp/nlopt.l
@@ -166,7 +166,7 @@
 
 (defun nlopt-optimize
   (&key
-   ((:initial-state x0) (float-vector 1 9))
+   ((:initial-state x0) (float-vector 0 0))
    ((:state-min-vector x-min) #F(0 0 ))
    ((:state-max-vector x-max) #F(10 10))
    ((:state-dimension m-x) (length x0))
@@ -248,7 +248,7 @@
 	     Sbplx
 	     ))
     (nlopt-optimize :ftol 1e-10 :xtol 1e-10 :eqthre 1e-10
-		   :max-time 10
-		   :alg alg)))
+		    :max-time 1
+		    :alg alg)))
 
 ;(nlopt-optmize)

--- a/eus_nlopt/include/nlopt_solver.h
+++ b/eus_nlopt/include/nlopt_solver.h
@@ -34,7 +34,7 @@ public:
 	 */
 	void InequalityConstraintCost(double* h);
 	//
-	double *fbuf, *gbuf, *hbuf, *dfbuf, *dgbuf, *dhbuf ;
+	double *fbuf, *gbuf, *hbuf, *dfbuf, *dgbuf, *dhbuf, *x ;
 	//
 	//
 	// util functions vv
@@ -104,12 +104,18 @@ public:
 			my_log("Fail: Roundoff errors limited progress.");
 		}
 
+		//
+		// if ( this->f ) (*(this->f))(this->x,fbuf) ;
+		// if ( this->g ) (*(this->g))(this->x,gbuf) ;
+		// if ( this->h ) (*(this->h))(this->x,hbuf) ;
+		//
 		my_log("Number of iteration.:	", this->iteration - 1);
+		this->ObjectiveFunctionCost();
 		my_log("object function: ", this->fbuf[0]) ;
 		my_log("  | where     x: ", this->x, this->m_x) ;
-		//this->EqualityConstraintCost(this->gbuf) ;
+		this->EqualityConstraintCost(this->gbuf) ;
 		my_log("  |   eq constt: ", this->gbuf, this->m_g) ;
-		//this->InequalityConstraintCost(this->hbuf) ;
+		this->InequalityConstraintCost(this->hbuf) ;
 		my_log("  |  neq constt: ", this->hbuf, this->m_h) ;
 	}
 
@@ -119,7 +125,8 @@ public:
 
 private:
 		nlopt_opt solver;
-		double* x;
+		nlopt_opt core_solver;
+		// double* x;
 		int (*f)(double*,double*), (*df)(double*,double*);
 		//! 等式制約条件
 		int (*g)(double*,double*), (*dg)(double*,double*);

--- a/eus_nlopt/src/nlopt_wrapper.cpp
+++ b/eus_nlopt/src/nlopt_wrapper.cpp
@@ -34,9 +34,12 @@ double* optimize(double* x,
 		int log,
 		Optimization::NLopt::Algorithm algorithm,
 		double* fbuf, double* dfbuf, double* gbuf, double* dgbuf, double* hbuf, double* dhbuf) {
+  // if ( ! nos_buf ) {
 	NLoptSolver nos(x, x_min, x_max, f, df, g, dg, h, dh, m_x, m_g, m_h, ftol,xtol,eqthre,max_eval,max_time,
 			(Optimization::NLopt::Algorithm) algorithm);
 	nos_buf = &nos ;
+	free(nos.fbuf); free(nos.dfbuf); free(nos.gbuf);
+	free(nos.dgbuf); free(nos.hbuf); free(nos.dhbuf);
 	nos.fbuf = fbuf ; nos.dfbuf = dfbuf ;
 	nos.gbuf = gbuf ; nos.dgbuf = dgbuf ;
 	nos.hbuf = hbuf ; nos.dhbuf = dhbuf ;


### PR DESCRIPTION
いくつかのソルバで，収束計算の閾値が正しくセットされていなかったので直しました．
また，解放されない値がソルバ内にあったので，解放するようにしました．
