### PR TITLE
[jsk_footstep_planner/simple_neighbored_graph.h] add missing include string

### DIFF
--- a/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h
@@ -37,6 +37,7 @@
 #ifndef JSK_FOOTSTEP_PLANNER_SIMPLE_NEIGHBORED_GRAPH_
 #define JSK_FOOTSTEP_PLANNER_SIMPLE_NEIGHBORED_GRAPH_
 
+#include <string>
 #include "jsk_footstep_planner/graph.h"
 
 namespace jsk_footstep_planner


### PR DESCRIPTION
In some environment, build fails.

```bash
In file included from /home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/src/simple_neighbored_graph.cpp:36:0:
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h:73:17: error: field 'name_' has incomplete type
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h: In constructor 'jsk_footstep_planner::SimpleNeighboredNode::SimpleNeighboredNode(const string&)':
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h:49:52: error: class 'jsk_footstep_planner::SimpleNeighboredNode' does not have any field named 'name_'
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h: In member function 'virtual std::string jsk_footstep_planner::SimpleNeighboredNode::getName()':
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h:66:35: error: return type 'std::string {aka struct std::basic_string<char>}' is incomplete
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h:66:44: error: 'name_' was not declared in this scope
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h: In member function 'bool jsk_footstep_planner::SimpleNeighboredNode::operator==(jsk_footstep_planner::SimpleNeighboredNode&)':
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h:69:14: error: 'name_' was not declared in this scope
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h: In member function 'virtual jsk_footstep_planner::Graph<jsk_footstep_planner::SimpleNeighboredNode>::StatePtr jsk_footstep_planner::SimpleNeighboredGraph::findNode(const string&)':
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h:106:29: error: no match for 'operator==' in 's.boost::shared_ptr<T>::operator-> [with T = jsk_footstep_planner::SimpleNeighboredNode]()->jsk_footstep_planner::SimpleNeighboredNode::getName() == name'
/home/furushchev/ros/hydro/src/jsk-ros-pkg/jsk_control/jsk_footstep_planner/include/jsk_footstep_planner/simple_neighbored_graph.h:106:29: note: candidates are:
/usr/include/c++/4.6/bits/stl_vector.h:1273:5: note: template<class _Tp, class _Alloc> bool std::operator==(const std::vector<_Tp, _Alloc>&, const std::vector<_Tp, _Alloc>&)
/usr/include/c++/4.6/bits/postypes.h:218:5: note: template<class _StateT> bool std::operator==(const std::fpos<_StateT>&, const std::fpos<_StateT>&)
/usr/include/c++/4.6/bits/allocator.h:127:5: note: template<class _Tp> bool std::operator==(const std::allocator<_Tp1>&, const std::allocator<_Tp1>&)
/usr/include/c++/4.6/bits/allocator.h:122:5: note: template<class _T1, class _T2> bool std::operator==(const std::allocator<_T1>&, const std::allocator<_T2>&)
/usr/include/c++/4.6/bits/stl_iterator.h:335:5: note: template<class _IteratorL, class _IteratorR> bool std::operator==(const std::reverse_iterator<_IteratorL>&, const std::reverse_iterator<_IteratorR>&)
/usr/include/c++/4.6/bits/stl_iterator.h:285:5: note: template<class _Iterator> bool std::operator==(const std::reverse_iterator<_Iterator>&, const std::reverse_iterator<_Iterator>&)
/usr/include/c++/4.6/bits/stl_pair.h:201:5: note: template<class _T1, class _T2> bool std::operator==(const std::pair<_T1, _T2>&, const std::pair<_T1, _T2>&)
/usr/include/c++/4.6/ext/new_allocator.h:123:5: note: template<class _Tp> bool __gnu_cxx::operator==(const __gnu_cxx::new_allocator<_Tp>&, const __gnu_cxx::new_allocator<_Tp>&)
/usr/include/c++/4.6/bits/stl_iterator.h:805:5: note: template<class _Iterator, class _Container> bool __gnu_cxx::operator==(const __gnu_cxx::__normal_iterator<_Iterator, _Container>&, const __gnu_cxx::__normal_iterator<_Iterator, _Container>&)
/usr/include/c++/4.6/bits/stl_iterator.h:799:5: note: template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator==(const __gnu_cxx::__normal_iterator<_IteratorL, _Container>&, const __gnu_cxx::__normal_iterator<_IteratorR, _Container>&)
make[2]: *** [CMakeFiles/jsk_footstep_planner.dir/src/simple_neighbored_graph.cpp.o] Error 1
make[1]: *** [CMakeFiles/jsk_footstep_planner.dir/all] Error 2
make: *** [all] Error 2
[jsk_footstep_planner] <== '/home/furushchev/ros/hydro/build/jsk_footstep_planner/build_env.sh /usr/bin/make' failed with return code '2'
```