### PR TITLE
[cmd_vel_smoother] add cmd_vel_smoother

### DIFF
--- a/cmd_vel_smoother/CMakeLists.txt
+++ b/cmd_vel_smoother/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cmd_vel_smoother)
+
+find_package(catkin REQUIRED COMPONENTS
+  dynamic_reconfigure
+  geometry_msgs
+  roscpp
+)
+
+find_package(Boost REQUIRED COMPONENTS system)
+
+generate_dynamic_reconfigure_options(
+  cfg/CmdVelSmoother.cfg)
+
+catkin_package(
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+)
+
+add_executable(cmd_vel_smoother src/cmd_vel_smoother.cpp)
+target_link_libraries(cmd_vel_smoother
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
+
+add_dependencies(cmd_vel_smoother ${PROJECT_NAME}_gencfg)
+
+install(TARGETS cmd_vel_smoother cmd_vel_smoother
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS)

--- a/cmd_vel_smoother/cfg/CmdVelSmoother.cfg
+++ b/cmd_vel_smoother/cfg/CmdVelSmoother.cfg
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+# set up parameters that we care about
+PACKAGE = 'cmd_vel_smoother'
+
+try:
+    import imp
+    imp.find_module(PACKAGE)
+    from dynamic_reconfigure.parameter_generator_catkin import *
+except:
+    import roslib; roslib.load_manifest(PACKAGE)
+    from dynamic_reconfigure.parameter_generator import *
+
+gen = ParameterGenerator()
+gen.add("x_acc_lim", double_t, 0, "", 0.1)
+gen.add("y_acc_lim", double_t, 0, "", 0.1)
+gen.add("yaw_acc_lim", double_t, 0, "", 0.1)
+gen.add("desired_rate", double_t, 0, "", 10.0)
+gen.add("decel_factor", double_t, 0, "", 0.9)
+gen.add("interpolate_max_frame", int_t, 0, "", 5)
+
+exit(gen.generate(PACKAGE, "cmd_vel_smoother", "CmdVelSmoother"))

--- a/cmd_vel_smoother/launch/cmd_vel_smoother.launch
+++ b/cmd_vel_smoother/launch/cmd_vel_smoother.launch
@@ -1,0 +1,14 @@
+<launch>
+  <node name="cmd_vel_smoother" pkg="cmd_vel_smoother" type="cmd_vel_smoother" output="screen">
+    <remap from="input" to="/base_controller/command_unchecked" />
+    <remap from="output" to="/base_controller/command" />
+
+    <param name="desired_rate" value="10.0" />
+    <param name="x_acc_lim" value="1.0" />
+    <param name="y_acc_lim" value="2.0" />
+    <param name="yaw_acc_lim" value="0.1" />
+    <param name="decel_factor" value="0.8" />
+    <param name="max_count" value="5" />
+  </node>
+</launch>
+        

--- a/cmd_vel_smoother/package.xml
+++ b/cmd_vel_smoother/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package>
+  <name>cmd_vel_smoother</name>
+  <version>0.1.6</version>
+  <description>The cmd_vel_smoother package</description>
+
+  <maintainer email="furushchev@jsk.imi.i.u-tokyo.ac.jp">Yuki Furuta</maintainer>
+  <license>BSD</license>
+  <author email="furushchev@jsk.imi.i.u-tokyo.ac.jp">Yuki Furuta</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
+
+  <export>
+  </export>
+</package>

--- a/cmd_vel_smoother/src/cmd_vel_smoother.cpp
+++ b/cmd_vel_smoother/src/cmd_vel_smoother.cpp
@@ -1,0 +1,119 @@
+#include <cmath>
+#include <boost/shared_ptr.hpp>
+#include <ros/ros.h>
+#include <dynamic_reconfigure/server.h>
+#include <cmd_vel_smoother/CmdVelSmootherConfig.h>
+#include <geometry_msgs/Twist.h>
+
+template<class T> inline T sgn(T val) { return val > 0 ? 1.0 : -1.0; }
+
+namespace dyn = dynamic_reconfigure;
+
+class VelocitySmootherNode
+{
+  ros::NodeHandle nh_, pnh_;
+  ros::Publisher  pub_;
+  ros::Subscriber sub_;
+  ros::Timer timer_;
+
+  boost::mutex cfg_mutex_;
+  typedef cmd_vel_smoother::CmdVelSmootherConfig Config;
+  boost::shared_ptr<dyn::Server<Config> > dyn_srv_;
+  
+  int interpolate_max_frame_, count_;
+  double desired_rate_;
+  double decel_factor_, decel_;
+  double x_acc_lim_, y_acc_lim_, yaw_acc_lim_;
+  ros::Time latest_time_;
+  geometry_msgs::Twist::ConstPtr latest_vel_;
+  geometry_msgs::Twist::Ptr pub_vel_;
+
+public:
+  ros::Duration timerDuration() {
+    return ros::Duration(1./(desired_rate_ * 2.2));
+  }
+
+  void dynConfigCallback(Config &cfg, uint32_t level) {
+    boost::mutex::scoped_lock lock(cfg_mutex_);
+    x_acc_lim_ = cfg.x_acc_lim;
+    y_acc_lim_ = cfg.y_acc_lim;
+    yaw_acc_lim_ = cfg.yaw_acc_lim;
+    decel_factor_ = cfg.decel_factor;
+    interpolate_max_frame_ = cfg.interpolate_max_frame;
+
+    if(desired_rate_ != cfg.desired_rate) {
+      desired_rate_ = cfg.desired_rate;
+      if (timer_.isValid()) {
+        ros::Duration d = timerDuration();
+        timer_.setPeriod(d);
+        ROS_INFO_STREAM("timer loop rate is changed to " << 1.0 / d.toSec() << "[Hz]");
+      }
+    }
+  }
+
+  void velCallback(const geometry_msgs::Twist::ConstPtr &msg){
+    latest_time_ = ros::Time::now();
+    latest_vel_ = msg;
+    count_ = 0;
+    pub_.publish(msg);
+  }
+
+  void timerCallback(const ros::TimerEvent& event){
+    if (count_ > interpolate_max_frame_) return;
+    if (latest_vel_ == NULL) return;
+
+    double past_sec = (ros::Time::now() - latest_time_).toSec();
+    if (past_sec < 1./desired_rate_) return;
+
+    double g_x   = std::abs(latest_vel_->linear.x  / past_sec);
+    double g_y   = std::abs(latest_vel_->linear.y  / past_sec);
+    double g_yaw = std::abs(latest_vel_->angular.z / past_sec);
+
+    ROS_DEBUG_STREAM("G: (" << g_x << ", " << g_y << ", " << g_yaw << ") detected");
+
+    bool need_publish = false;
+    if (g_x > x_acc_lim_) {
+      pub_vel_->linear.x = (g_x - x_acc_lim_) * past_sec * sgn(latest_vel_->linear.x);
+      need_publish = true;
+    }
+
+    if (g_y > y_acc_lim_) {
+      pub_vel_->linear.y = (g_y - y_acc_lim_) * past_sec * sgn(latest_vel_->linear.y);
+      need_publish = true;
+    }
+
+    if (g_yaw > yaw_acc_lim_) {
+      pub_vel_->angular.z = (g_yaw - yaw_acc_lim_) * past_sec * sgn(latest_vel_->angular.z);
+      need_publish = true;
+    }
+
+    if (need_publish)
+      pub_.publish(*pub_vel_);
+    count_++;
+    decel_ *= decel_factor_;
+  }
+
+  VelocitySmootherNode(): nh_(), pnh_("~") {
+    latest_time_ = ros::Time::now();
+
+    dyn_srv_ = boost::make_shared<dyn::Server<Config> >(nh_);
+    dyn::Server<Config>::CallbackType f = boost::bind(&VelocitySmootherNode::dynConfigCallback, this, _1, _2);
+    dyn_srv_->setCallback(f);
+    
+    pub_vel_ = boost::shared_ptr<geometry_msgs::Twist>(new geometry_msgs::Twist());
+    pub_ = nh_.advertise<geometry_msgs::Twist>("output", 100);
+    sub_ = nh_.subscribe("input", 1, &VelocitySmootherNode::velCallback, this);
+    timer_ = nh_.createTimer(timerDuration(), &VelocitySmootherNode::timerCallback, this);
+  };
+  ~VelocitySmootherNode() {};
+
+};
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "cmd_vel_smoother");
+  VelocitySmootherNode n;
+  ros::spin();
+
+  return 0;
+}
+


### PR DESCRIPTION
This should solve https://github.com/jsk-ros-pkg/jsk_robot/issues/198 https://github.com/jsk-ros-pkg/jsk_common/issues/160
Tested on PR1012

when publishing rate of original `cmd_vel` (blue line) is under control loop, this node publishes interpolating messages (red line)
(monitoring if robot violates acceleration/deceleration (occured by rapid stop))

![cmd_vel_smoothed](https://cloud.githubusercontent.com/assets/1901008/10489307/7ef58642-72d7-11e5-96a0-8c3b619b7aa2.png)
