### PR TITLE
[contact_states_observer] Support multiple success states.

### DIFF
--- a/contact_states_observer/euslisp/contact-states-observer.l
+++ b/contact_states_observer/euslisp/contact-states-observer.l
@@ -50,7 +50,8 @@
      ))
   (:get-result
    ()
-   (eq :success result)
+   "return t if result is one of :success, :success0, and so on"
+   (substringp (string :success) (string result))
    )
   )
 


### PR DESCRIPTION
Check result symbol which has "success" in its name