### PR TITLE
[eus_qp][contact-optimization.l] add dummy-contact-constraint and test function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,12 @@ notifications:
     on_failure: always
   slack: jsk-robotics:Av7tc8wj3IWkLYvlTzHE7x2g
 env:
-  - ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=true
-  - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=true
+  global:
+    - ROS_PARALLEL_TEST_JOBS="-j1"
+    - CATKIN_PARALLEL_TEST_JOBS="-j1"
+  matrix:
+    - ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=true
+    - ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=true
 script: source .travis/travis.sh
 before_script:
   - export ROS_PARALLEL_JOBS="-j2 -l2"

--- a/eus_qp/euslisp/contact-optimization.l
+++ b/eus_qp/euslisp/contact-optimization.l
@@ -564,6 +564,20 @@
    (send-super :init :name name))
   )
 
+(defclass dummy-contact-constraint
+  :super contact-constraint
+  )
+
+(defmethod dummy-contact-constraint
+  (:init
+   (&key (name))
+   "Calc conatraint param list for dummy.
+    This can be used for hard-grasping contact, where no constraint is necessary."
+   (setq constraint-param-list
+         (calc-constraint-param-list-for-dummy))
+   (send-super :init :name name))
+  )
+
 (defun force-axis->index (ax)
   (case ax
     (:fx 0) (:fy 1) (:fz 2)
@@ -734,6 +748,14 @@
            (setf (elt (car ret) slide-idx) -1)
            (setf (elt (cadr ret) slide-idx) 1)))
     (list :matrix ret :vector (list 0 0))
+    ))
+
+(defun calc-constraint-param-list-for-dummy
+  ()
+  "Calc conatraint param list for dummy.
+   all elements of matrix and vector are zero."
+  (let ((ret (mapcar #'(lambda (x) (make-list 6 :initial-element 0)) '(0))))
+    (list :matrix ret :vector (list 0))
     ))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/eus_qp/euslisp/test-contact-wrench-opt.l
+++ b/eus_qp/euslisp/test-contact-wrench-opt.l
@@ -516,6 +516,16 @@
    (list (send *cbox* :worldcoords) (send *cbox* :get :face-coords-2))
    ))
 
+(defun demo-cbox-wrench-calc-17
+  ()
+  "Demo for cbox wrench calculation by dummy-contact-constraint."
+  (set-cbox-pose-neutral)
+  (demo-cbox-wrench-calc-comon
+   (list (instance dummy-contact-constraint :init))
+   (list (send *cbox* :get :face-coords-2))
+   ))
+
+
 (defun demo-cbox-wrench-calc-all
   (&key (press-enter-p t))
   (let ((ret))


### PR DESCRIPTION
接触を保つための条件（法線，摩擦，圧力中心）のいずれも必要無いような，
堅い把持のconstraintのクラスとそのテストを追加しました．

constraint-matrixは1行6列，constraint-vectorは1要素で，全てゼロが入っています．
名前は，dummy-constact-constraintとしましたが，
もしもhard-grasp-contact-constraintとかの方が良かったら変更します．