### PR TITLE
Revert eus_qp qp_lib.cpp Eigen usage hack

### DIFF
--- a/eus_qp/CMakeLists.txt
+++ b/eus_qp/CMakeLists.txt
@@ -2,7 +2,7 @@ project(eus_qp)
 
 cmake_minimum_required(VERSION 2.4.6)
 
-find_package(catkin COMPONENTS cmake_modules roscpp rostest)
+find_package(catkin COMPONENTS cmake_modules rostest)
 find_package(Eigen REQUIRED)
 
 include_directories(${Eigen_INCLUDE_DIRS})

--- a/eus_qp/package.xml
+++ b/eus_qp/package.xml
@@ -12,7 +12,6 @@
   <build_depend>euslisp</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>rostest</build_depend>
 
   <run_depend>euslisp</run_depend>

--- a/eus_qp/src/qp_lib.cpp
+++ b/eus_qp/src/qp_lib.cpp
@@ -2,21 +2,6 @@
 #include <iostream>
 #include <Eigen/Dense>
 
-// hack
-#include <ros/common.h>
-#if ROS_VERSION_GE(ROS_VERSION_MAJOR, ROS_VERSION_MINOR, ROS_VERSION_PATCH, 1, 11, 10)
-namespace Eigen 
-{
-  namespace internal
-  {
-    float abs(float a) { return std::abs(a); }
-    float sqrt(float v) { return ::sqrt(v); }
-  }
-}
-#endif
-
-//#define Eigen::interal::abs std::abs
-
 #include "eiquadprog.hpp"
 
 using namespace Eigen;


### PR DESCRIPTION
Revert eus_qp qp_lib.cpp Eigen usage hack by @garaemon ,
because we can build this program on travis without this hack (https://github.com/jsk-ros-pkg/jsk_control/commit/4937ac04d0c1beceb8c4c92eac258c00549943f9) 
and this program itself is not related with ros program.

In addition, recently eus_qp travis build cannot succeed
https://s3.amazonaws.com/archive.travis-ci.org/jobs/112049705/log.txt
```

[eus_qp] Scanning dependencies of target eus_qp                                 

[eus_qp] [ 50%] [100%] Building CXX object CMakeFiles/eus_qp.dir/src/qp_lib.cpp.o 

[eus_qp] Building CXX object CMakeFiles/euq_qp_test.dir/src/example.cpp.o       

[eus_qp] /workspace/ros/ws_jsk_control/src/jsk_control/eus_qp/src/qp_lib.cpp:6:24: fatal error: ros/common.h: No such file or directory 

[eus_qp]  #include <ros/common.h>                                               

[eus_qp]                         ^                                              

[eus_qp] compilation terminated.                                                

[eus_qp] In file included from /workspace/ros/ws_jsk_control/src/jsk_control/eus_qp/src/example.cpp:58:0: 

[eus_qp] /workspace/ros/ws_jsk_control/src/jsk_control/eus_qp/src/qp_lib.cpp:6:24: fatal error: ros/common.h: No such file or directory 

[eus_qp]  #include <ros/common.h>                                               

[eus_qp]                         ^                                              

[eus_qp] compilation terminated.                                                

[eus_qp] make[2]: *** [CMakeFiles/eus_qp.dir/src/qp_lib.cpp.o] Error 1          

[eus_qp] make[1]: *** [CMakeFiles/eus_qp.dir/all] Error 2                       

[eus_qp] make[1]: make[2]: *** [CMakeFiles/euq_qp_test.dir/src/example.cpp.o] Error 1*** Waiting for unfinished jobs.... 

[eus_qp] make[1]: *** [CMakeFiles/euq_qp_test.dir/all] Error 2                  

[eus_qp] make: *** [all] Error 2                                                

[eus_qp] <== '/workspace/ros/ws_jsk_control/build/eus_qp/build_env.sh /usr/bin/make --jobserver-fds=3,4 -j' failed with return code '2' 

Failed   <== eus_qp                  [ 8.0 seconds ]                            

[build] Calculating new jobs...                     
```