### PR TITLE
[eus_qp/euslisp] add 6d-min-max-contact-constraint class and test

### DIFF
--- a/eus_qp/euslisp/contact-optimization.l
+++ b/eus_qp/euslisp/contact-optimization.l
@@ -626,6 +626,31 @@
    (send-super :init :name name))
   )
 
+(defclass 6d-min-max-contact-constraint
+  :super contact-constraint
+  :slots (max-wrench)
+  )
+
+(defmethod 6d-min-max-contact-constraint
+  (:init
+   (tmp-max-wrench &key (name))
+   "Calc 6D wrench min-max constraint.
+    tmp-max-wrench should be 6D vector of max wrench.
+    Absolute values of min wrench and max wrench are same.
+    This can be used for approximating the grasping contact."
+   (setq max-wrench tmp-max-wrench)
+   (let ((ret (apply
+               #'append
+               (mapcar #'(lambda (axis max-value)
+                           (list (calc-constraint-param-list-for-min-max axis (- max-value) :min/max :min)
+                                 (calc-constraint-param-list-for-min-max axis max-value :min/max :max)))
+                       '(:fx :fy :fz :nx :ny :nz) (coerce max-wrench cons)))))
+     (setq constraint-param-list
+           (list :matrix (apply #'append (mapcar #'(lambda (x) (cadr (memq :matrix x))) ret))
+                 :vector (apply #'append (mapcar #'(lambda (x) (cadr (memq :vector x))) ret)))))
+   (send-super :init :name name))
+  )
+
 (defun force-axis->index (ax)
   (case ax
     (:fx 0) (:fy 1) (:fz 2)

--- a/eus_qp/euslisp/test-contact-wrench-opt.l
+++ b/eus_qp/euslisp/test-contact-wrench-opt.l
@@ -551,6 +551,16 @@
    (list (send *cbox* :worldcoords) (send *cbox* :get :face-coords-2))
    ))
 
+(defun demo-cbox-wrench-calc-17
+  ()
+  "Demo for cbox wrench calculation by 6d-min-max-contact-constraint. cbox is neutral pos rot."
+  (set-cbox-pose-neutral)
+  (demo-cbox-wrench-calc-comon
+   (list (instance 6d-min-max-contact-constraint :init (float-vector 1000 1000 1000 100 100 100)))
+   (list (send *cbox* :get :face-coords-2))
+   ))
+
+
 (defun demo-cbox-wrench-calc-all
   (&key (press-enter-p t))
   (let ((ret))


### PR DESCRIPTION
力・モーメントの上下限を指定する contact constraintのクラスを追加しました．
1次元片側の`calc-constraint-param-list-for-min-max`が，
6次元 & 両側 なので，12個並んだ制約になります．
