### PR TITLE
[jsk_calibration] Modify checkerboard spacing values and modify README

### DIFF
--- a/jsk_calibration/hrp2jsknts_calibration/README.md
+++ b/jsk_calibration/hrp2jsknts_calibration/README.md
@@ -26,19 +26,20 @@ you run `capture_data.launch`
 
 ### 3. Estimate parameter
 1. If you have some samples failed to capture data, please remove line from initial_poses.yaml
-2. start roscore
+2. Check `spacing_x:` and `spacing_y:` values of `checkerboards:` in `estimate_params/config/system.yaml`. Please edit these values to be measurement values for actual checkerboard.
+3. start roscore
 
   ```
 $ rossetlocal
 $ roscore
 ```
-3. run `calibrate_hrp2jsknts.sh`.
+4. run `calibrate_hrp2jsknts.sh`.
 
   ```
 $ rosssetlocal
 $ ./calibrate_hrp2jsknts.sh
 ```
-4. After a while (1 hour), you will get calibrated urdf file. The name of urdf file is
+5. After a while (1 hour), you will get calibrated urdf file. The name of urdf file is
 `robot_calibrated_YYYY_MM_DD_HH_SS.xml`.
 Uncalibrated urdf file is `robot_uncalibrated_YYYY_MM_DD_HH_SS.xml`.
 

--- a/jsk_calibration/hrp2w_calibration/estimate_params/config/system.yaml
+++ b/jsk_calibration/hrp2w_calibration/estimate_params/config/system.yaml
@@ -46,8 +46,8 @@ checkerboards:
   mmurooka_board:
     corners_x: 6
     corners_y: 5
-    spacing_x: 0.02752
-    spacing_y: 0.02752
+    spacing_x: 0.03
+    spacing_y: 0.03
 
 transforms:
   LARM_chain_cb:   [0.128, 0, 0.075, 0, 0, 0]

--- a/jsk_calibration/hrp2w_calibration/estimate_params/config/system.yaml
+++ b/jsk_calibration/hrp2w_calibration/estimate_params/config/system.yaml
@@ -46,8 +46,8 @@ checkerboards:
   mmurooka_board:
     corners_x: 6
     corners_y: 5
-    spacing_x: 0.03
-    spacing_y: 0.03
+    spacing_x: 0.02752
+    spacing_y: 0.02752
 
 transforms:
   LARM_chain_cb:   [0.128, 0, 0.075, 0, 0, 0]


### PR DESCRIPTION
In hrp2w_calibration, modify checkerboard spacing x,y parameters to be measurement values for actual checkerboard, and add this procedure to README.