### PR TITLE
fix center position of footsteps

### DIFF
--- a/jsk_footstep_planner/README.md
+++ b/jsk_footstep_planner/README.md
@@ -8,3 +8,12 @@ jsk_footstep_planner
 * `roslaunch hrpsys_gazebo_tutorials gazebo_jaxon_no_controllers.launch`
 * `rtmlaunch hrpsys_gazebo_tutorials jaxon_hrpsys_bringup.launch KINEMATICS_MODE:=true`
 * `roslaunch jsk_footstep_planner optimistic_footstep_planner.launch USE_SIMPLE_FOOTSTEP_CONTROLLER:=true GLOBAL_FRAME:=odom USE_PERCEPTION:=false`
+
+
+## Tips footstep_planner and footstep_marker
+
+* Footsteps in footstep_planner are represented by a center of a rectangle.
+
+* Footsteps in footstep_marker are represented by end-coords of robot model.
+
+* The difference between footstep_planner and footstep_marker can be adjusted by parameters ~lleg_footstep_offset and ~rleg_footstep_offset of footstep_marker

--- a/jsk_footstep_planner/include/jsk_footstep_planner/footstep_marker.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/footstep_marker.h
@@ -186,6 +186,7 @@ namespace jsk_footstep_planner
     std::string lleg_end_coords_, rleg_end_coords_;
     PosePair::Ptr original_foot_poses_;
     Eigen::Affine3f lleg_goal_pose_, rleg_goal_pose_;
+    Eigen::Affine3f current_lleg_offset_, current_rleg_offset_;
     Eigen::Vector3f lleg_footstep_offset_, rleg_footstep_offset_;
     double default_footstep_margin_;
     


### PR DESCRIPTION
footstep_plannerとfootstep_markerでfootstepの座標がずれていたのを修正しました。

plannterでは、四角形の中心をfootstepの座標として使っています。

markerでは、モデルのlleg/rlegのend-coordsを座標として使っています。

footstep_markerのパラメータ、lleg/rleg_footstep_offsetで調整します。