### PR TITLE
Add go-pos to footstep controller

### DIFF
--- a/jsk_footstep_controller/CMakeLists.txt
+++ b/jsk_footstep_controller/CMakeLists.txt
@@ -27,7 +27,7 @@ add_service_files(FILES
 
 add_action_files(
   DIRECTORY action
-  FILES LookAroundGround.action
+  FILES LookAroundGround.action GoPos.action
 )
 generate_messages(
   DEPENDENCIES actionlib_msgs std_msgs geometry_msgs sensor_msgs)

--- a/jsk_footstep_controller/action/GoPos.action
+++ b/jsk_footstep_controller/action/GoPos.action
@@ -1,0 +1,21 @@
+# goal
+uint8 NEW_TARGET=0
+uint8 OVER_WRITE=1
+uint8 ABSOLUTE_NEW_TARGET=2
+uint8 ABSOLUTE_OVER_WRITE=3
+float32 x # [ m ]
+float32 y # [ m ]
+float32 theta # [ degree ]
+# geometry_msgs/PoseStamped pose ## used for absolute
+uint8 action # 0 (NEW_TARGET), 1 (OVER_WRITE) over write old destination while walking
+---
+# result
+---
+# feedback
+uint8 PRE_PLANNING=0
+uint8 PLANNING=1
+uint8 WALKING=2
+uint8 WAITING=3
+uint8 FINISH=4
+uint8 status
+int32 remaining_steps

--- a/jsk_footstep_controller/euslisp/go-pos-client.l
+++ b/jsk_footstep_controller/euslisp/go-pos-client.l
@@ -1,0 +1,72 @@
+;;(ros::roseus-add-msgs "jsk_footstep_msgs")
+(ros::roseus-add-msgs "jsk_footstep_controller")
+(load "package://hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l")
+
+(ros::roseus "go_pos_client" :anonymous nil)
+
+(defclass go-pos-client
+  :super propertied-object
+  :slots (client feedback ri
+          ;; initial-coords
+          ;; finished-goal-id
+          ;; target-x target-y target-th
+         )
+  )
+
+(defmethod go-pos-client
+  (:init
+   (&key (wait t))
+   (setq client
+         (instance ros::simple-action-client :init
+                   "go_pos_server" jsk_footstep_controller::GoPosAction))
+   ;; not using feedback
+   ;;(setq (client . ros::action-feedback-cb) '(lambda (msg) (send self :feedback-cb msg)))
+   (setq ri (instance rtm-ros-robot-interface :define-all-ROSBridge-srv-methods))
+   (when wait (send client :wait-for-server))
+   self)
+  (:feedback-cb (msg) (setq feedback msg))
+  (:wait-client
+   (&optional (timeout 0))
+   (let ((ret (send client :wait-for-result :timeout timeout)))
+     (when (or ret
+               (= (client . ros::simple-state) ros::*simple-goal-state-done*))
+       (setq ret (send client :get-result)))
+     ret))
+  (:go-pos
+   (x y th &key (overwrite nil) (wait t))
+   (let ((walking? (send self :is-walking)))
+     (cond
+      ((and walking? (not overwrite))
+       (warn "robot is walking now!~%")
+       (return-from :go-pos))
+      ((and walking? overwrite)
+       (when (< (length (car walking?)) 5) ;; few remaining steps
+         (warn "few remaining steps ~A~%" walking?)
+         (return-from :go-pos)))
+      ((and (not walking?) overwrite)
+       (warn "overwritting steps was required, but robot is not stepping!~%")
+       (return-from :go-pos))
+      )
+     (let ((goal (instance jsk_footstep_controller::GoPosActionGoal :init)))
+       (send goal :goal :x x)
+       (send goal :goal :y y)
+       (send goal :goal :theta th)
+       (send goal :goal :action
+             (if (not walking?)
+                 jsk_footstep_controller::GoPosGoal::*NEW_TARGET*
+               jsk_footstep_controller::GoPosGoal::*OVER_WRITE*))
+       (send client :send-goal goal)
+       ))
+   (if wait (send self :wait-client) t)
+   )
+  (:go-pos-no-wait
+   (x y th &key (overwrite nil))
+   (send self :go-pos x y th :overwrite overwrite :wait nil))
+  (:is-walking ()
+   (let ((remaining-steps (send ri :get-remaining-foot-step-sequence-current-index)))
+     (if (car remaining-steps)
+         remaining-steps nil)))
+  ;;(:can-overwrite () )
+  )
+
+(warn "(setq *gp* (instance go-pos-client :init))~%(send *gp* :go-pos-no-wait 2 0 0)~%(send *gp* :go-pos-no-wait 2 1 0 :overwrite t)~%")

--- a/jsk_footstep_controller/euslisp/go-pos-server.l
+++ b/jsk_footstep_controller/euslisp/go-pos-server.l
@@ -1,0 +1,315 @@
+#!/usr/bin/env roseus
+
+(ros::roseus-add-msgs "jsk_footstep_msgs")
+(ros::roseus-add-msgs "jsk_footstep_controller")
+(load "package://jsk_footstep_controller/euslisp/util.l")
+
+;; The most simplest version to execute footsteps by :set-foot-steps
+;; method and have actionlib server interface
+(ros::roseus "go_pos_server" :anonymous nil)
+
+;;(setq *step-refine* (ros::get-param "~/use_step_refine"))
+(setq *step-refine* t)
+
+;;(setq *robot-name* (ros::get-param "/robot/type" (unix::getenv "ROBOT")))
+;;(load (robot-interface-file *robot-name*))
+;;(init-robot-from-name *robot-name*) ;; making *ri*
+;; just for calling service
+(load "package://hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l")
+(setq *ri* (instance rtm-ros-robot-interface :define-all-ROSBridge-srv-methods))
+
+;; setting for jaxon
+(setq *default-lleg-pos* (float-vector 0  100 0))
+(setq *default-rleg-pos* (float-vector 0 -100 0))
+(setq *default-lleg-rpy* (list 0 0 0))
+(setq *default-rleg-rpy* (list 0 0 0))
+
+;; setting parameters
+(setq *overwrite-offset* 2)
+(setq *footstep-refine-duration* 0.3)
+
+;; global variables
+(defun clear-variables ()
+  (setq *current-initial-coords* nil)
+  (setq *current-target-coords* nil)
+  (setq *current-steps* nil)
+  (setq *wait-until* nil)
+  (setq *status* jsk_footstep_controller::GoPosFeedback::*WAITING*)
+  (setq *previous-time* (ros::time-now))
+  )
+
+(defun publish-feedback (server &optional (steps -0))
+  (let ((msg (send server :feedback)))
+    (send msg :feedback :status *status*)
+    (send msg :feedback :remaining_steps steps)
+    (send server :publish-feedback msg)
+    ))
+
+(defun execute-cb (server goal)
+  (let (remaining-steps)
+
+    (cond
+     ;;; initial stete (waiting for new goal)
+     ((eq *status* jsk_footstep_controller::GoPosFeedback::*WAITING*)
+      ;; first time
+      (unless *current-initial-coords*
+        (let ((planning-goal
+               (make-go-pos-planning-msgs (send goal :goal :x)
+                                          (send goal :goal :y)
+                                          (send goal :goal :theta)
+                                          :lleg-offset (make-coords :pos *default-lleg-pos* :rpy *default-lleg-rpy*)
+                                          :rleg-offset (make-coords :pos *default-rleg-pos* :rpy *default-rleg-rpy*))))
+          ;;
+          (let ((steps (mapcar #'(lambda (f)
+                                   (footstep->coords f))
+                               (send planning-goal :goal :initial_footstep :footsteps))))
+            (setq *current-initial-coords* (midcoords 0.5 (car steps) (cadr steps))))
+          ;;
+          (let ((steps (mapcar #'(lambda (f)
+                                   (footstep->coords f))
+                               (send planning-goal :goal :goal_footstep :footsteps))))
+            (setq *current-target-coords*  (midcoords 0.5 (car steps) (cadr steps))))
+          ;;
+          (ros::ros-info "sending goal")
+          (send *planning-client* :send-goal planning-goal)
+          )
+        (setq *status* jsk_footstep_controller::GoPosFeedback::*PLANNING*)
+        (publish-feedback server (length remaining-steps))
+        (return-from execute-cb))
+      )
+     ;;; planning state (waiting for finish planning)
+     ((eq *status* jsk_footstep_controller::GoPosFeedback::*PLANNING*)
+      (publish-feedback server (length remaining-steps))
+      (let ((ret (send *planning-client* :wait-for-result :timeout 0.001)))
+        (cond
+         (ret ;; planning finished successfully
+          (let ((result (send (send *planning-client* :get-result) :result)))
+            ;; debug
+            (ros::publish *footstep-visualize-topic* result)
+            ;; execute
+            (let ((footstep-coords (footstep-array->coords result)))
+              ;; debug
+              (print-readable-coords footstep-coords)
+              (send *ri* :set-foot-steps-no-wait footstep-coords);; execute ...
+              (setq *current-steps* footstep-coords)
+              )
+            (setq *status* jsk_footstep_controller::GoPosFeedback::*WALKING*)
+            (publish-feedback server (length remaining-steps))
+            (ros::ros-info "execute-cb: exec new steps ~D" (length *current-steps*))
+            ))
+         ((= (*planning-client* . ros::simple-state) ros::*simple-goal-state-done*)
+          ;; planning done but not successfully
+          (clear-variables)
+          (send server :set-preempted)
+          ))
+        )
+      (return-from execute-cb)
+      )
+     ;;; walking state (waiting for overwriting target)
+     ((eq *status* jsk_footstep_controller::GoPosFeedback::*WALKING*)
+      ;; loop cycle check
+      (let ((now (ros::time-now)))
+        (when (< (send (ros::time- now *previous-time*) :to-sec) *footstep-refine-duration*)
+          (return-from execute-cb))
+        (setq *previous-time* now))
+
+      (setq remaining-steps
+            (send *ri* :get-remaining-foot-step-sequence-current-index))
+      (publish-feedback server (length (car remaining-steps)))
+
+      ;; finish walking
+      (unless (car remaining-steps)
+        (setq *status* jsk_footstep_controller::GoPosFeedback::*FINISH*)
+        (publish-feedback server 0)
+        (send server :set-succeeded (send server :result))
+        (clear-variables)
+        (return-from execute-cb))
+
+      ;; set new goal (over written old gol)
+      (when (and (server . ros::pending-goal)
+                 (= (server . ros::status)
+                    actionlib_msgs::GoalStatus::*preempting*))
+        (let* ((new-goal (server . ros::pending-goal))
+               (new-action (send new-goal :goal :action)))
+          (cond
+           ((< (cadr remaining-steps) (+ *overwrite-offset* 1 2))
+            ;; do nothing, because of few remaining steps
+            )
+           ((= new-action jsk_footstep_controller::GoPosGoal::*OVER_WRITE*) ;; go-pos over write
+            ;;
+            (let ((tgt-cds (make-coords :pos (float-vector (* 1000 (send new-goal :goal :x))
+                                                           (* 1000 (send new-goal :goal :y)) 0)))
+                  new-target error-cds)
+              (send tgt-cds :rotate (deg2rad (send new-goal :goal :theta)) :z)
+              (setq new-target (send (send *current-initial-coords* :copy-worldcoords) :transform tgt-cds))
+              (setq error-cds (send *current-target-coords* :transformation new-target))
+              ;;
+              (pprint (list 'new-target new-target))
+              (pprint (list 'error-cds error-cds))
+              ;;
+              (cond
+               ;;;
+               (;;(< (norm (send error-cds :pos)) 1000000000.0)
+                nil
+                (let ((new-target-step (send new-target :copy-worldcoords)))
+                  (cond
+                   ((eq (send (car (last *current-steps*)) :name) :lleg)
+                    (send new-target-step :transform (make-coords :pos *default-lleg-pos* :rpy *default-lleg-rpy*))
+                    (send new-target-step :name :lleg))
+                   (t
+                    (send new-target-step :transform (make-coords :pos *default-rleg-pos* :rpy *default-rleg-rpy*))
+                    (send new-target-step :name :rleg)))
+                  ;;
+                  (setq *current-steps* (append *current-steps* (list new-target-step)))
+                  )
+                )
+               ;;; replan
+               (t ;;
+                (let ((map->odom (send *tfl* :lookup-transform "map" "odom" (ros::time 0)))
+                      (offset *overwrite-offset*)) ;; replan offset ?
+                  (let ((steps (butlast (car remaining-steps)))
+                        (idx (cadr remaining-steps))
+                        istep newsteps trans start-steps start-leg)
+                    (setq istep (elt steps offset)) ;;
+                    (setq steps (subseq steps (+ offset 1)))
+                    (setq start-steps
+                          (mapcar #'(lambda (step)
+                                      (let ((cds (send step :copy-worldcoords)))
+                                        (send cds :transform map->odom :world) ;; convert odom(local) -> map(world)
+                                        (send cds :name (send step :name))
+                                        cds))
+                                  (if (eq (send istep :name) :lleg)
+                                      (list istep (car steps))
+                                    (list (car steps) istep))))
+                    (setq start-leg (if (eq (send istep :name) :lleg) :lleg :rleg))
+
+                    (pprint (list 'start-step start-steps))
+                    (pprint (list 'map->odom map->odom))
+
+                    (let ((planning-goal
+                           (make-footstep-planning-msgs
+                            start-steps new-target
+                            :start-leg  start-leg
+                            :lleg-offset (make-coords :pos *default-lleg-pos* :rpy *default-lleg-rpy*)
+                            :rleg-offset (make-coords :pos *default-rleg-pos* :rpy *default-rleg-rpy*))))
+
+                      (ros::ros-info "sending replanning goal")
+                      (send *planning-client* :send-goal planning-goal)
+
+                      (let ((ret (send *planning-client* :wait-for-result :timeout 120.0)))
+                        (ros::ros-info "replanning finished")
+                        (pprint remaining-steps)
+                        (cond
+                         (ret
+                          (let* ((result (send (send *planning-client* :get-result) :result))
+                                 (odom->map (send map->odom :inverse-transformation))
+                                 (step-ary (footstep-array->coords result))
+                                 send-steps)
+                            (ros::publish *footstep-visualize-topic* result)
+                            (setq send-steps (mapcar #'(lambda (x)
+                                                         (let ((cds (send x :copy-worldcoords)))
+                                                           (send cds :transform odom->map :world)
+                                                           (send cds :name (send x :name))
+                                                           cds)) step-ary))
+                            (setq *current-steps* step-ary) ;; ?
+                            ;;
+                            (pprint 'planned-step)
+                            (print-readable-coords step-ary)
+                            (pprint 'org-reamining)
+                            (pprint (list 'idx idx (+ idx offset 1)))
+                            (print-readable-coords steps)
+                            (pprint 'send-steps)
+                            (print-readable-coords send-steps)
+                            ;;
+                            (send *ri* :set-foot-steps-no-wait send-steps
+                                  :overwrite-footstep-index (+ idx offset 1))
+                            (setq *wait-until* (+ idx offset 1))
+                            ))
+                         (t
+                          (ros::ros-warn "replanning failed")
+                          ;;
+                          ))
+                        ))
+                    ))
+                ))
+              )
+            ;; dirty hack
+            (setq (server . ros::pending-goal) nil)
+            (setq (server . ros::status) actionlib_msgs::GoalStatus::*active*)
+            (setq (server . ros::goal) new-goal)
+            (setq (server . ros::goal-id) (send new-goal :goal_id))
+
+            (return-from execute-cb)
+            )
+           #|
+           ((= strategy jsk_footstep_controller::GoPosGoal::*NEW_TARGET*) ;; new target (overwrite old one)
+           ;;
+           (return-from execute-cb)
+           )
+           |#
+         )))
+      ;; refine steps ...
+
+      (when *step-refine*
+        ;; step may be refined based on map
+        (let (map-dest cds-diff wait-until)
+          (setq map-dest (copy-object (car (last *current-steps*))))
+
+          (setq cds-diff (calc-step-error-on-map (car remaining-steps) map-dest))
+
+          (setq remaining-steps (send *ri* :get-remaining-foot-step-sequence-current-index))
+          (when (and (> (length (car remaining-steps)) (+ *overwrite-offset* 4)) ;; offset + 4 (magic number)
+                     (or (not *wait-until*)
+                         (>= (cadr remaining-steps) *wait-until*)))
+            (pprint (list 'remaining-steps remaining-steps))
+            (refine-steps remaining-steps :offset *overwrite-offset*
+                          :expand-step cds-diff
+                          :exec t :collision-avoid t)
+            (setq *wait-until* (+ (cadr remaining-steps) *overwrite-offset* 1))
+            (ros::ros-info "execute-cb: step refine at ~D" *wait-until*)
+            )))
+      ;;
+      )
+     )
+    ))
+
+(defvar *tfl* (instance ros::transform-listener :init))
+(setq *planning-client*
+      (instance ros::simple-action-client :init
+                "footstep_planner" jsk_footstep_msgs::PlanFootstepsAction))
+(send *planning-client* :wait-for-server);;
+
+(clear-variables)
+(setq *server* (instance ros::simple-action-server :init
+                         (ros::get-name)
+                         jsk_footstep_controller::GoPosAction
+                         :groupname "go_pos_action"
+                         :execute-cb 'execute-cb
+                         ))
+
+;; debug
+(setq *footstep-visualize-topic* "/footstep_marker/output/plan_result")
+(ros::advertise *footstep-visualize-topic* jsk_footstep_msgs::FootstepArray 1)
+;;
+
+(ros::rate 20)
+(ros::ros-info "GoPos Server is ready as ~A" (ros::get-name))
+
+(while (ros::ok)
+  (send *server* :worker)
+  (send *server* :spin-once)
+  (ros::spin-once)
+  (ros::sleep)
+  )
+#| ;;test
+(setq remaining-steps
+      (let ((lstep (make-coords :pos (float-vector 150  100 0)))
+            (rstep (make-coords :pos (float-vector   0 -100 0)))
+            gl)
+        (send lstep :name :lleg)
+        (send rstep :name :rleg)
+        (list (list t t rstep lstep rstep)
+              2)
+        ))
+(setq new-target (make-coords :pos #f(3000 0 0)))
+|#

--- a/jsk_footstep_controller/euslisp/jaxon-footstep-controller.l
+++ b/jsk_footstep_controller/euslisp/jaxon-footstep-controller.l
@@ -23,130 +23,7 @@
     (send *ri* :wait-interpolation)
     )
   )
-
-(defun calc-map-diff (steps map->destination odom-cds)
-  (let (support-leg
-        map->ft
-        coords-difference
-        end-coords
-        )
-    (when (< (length steps) 2)
-      (if (eq (send map->destination :name) :lleg)
-          (setq support-leg :lleg end-coords "lleg_end_coords")
-        (setq support-leg :rleg end-coords "rleg_end_coords"))
-      (setq map->ft (send *tfl* :lookup-transform "map" end-coords (ros::time 0)))
-      (setq coords-difference
-            (send map->ft :transformation map->destination))
-      ;;(return-from calc-map-diff coords-difference)
-      (return-from calc-map-diff)
-      )
-
-    (if (eq (send (car steps) :name) :rleg)
-        (setq support-leg :lleg end-coords "lleg_end_coords")
-      (setq support-leg :rleg end-coords "rleg_end_coords"))
-    (let (
-          body->foot
-          abc->foot
-          foot->laststep
-          map->foot
-          map->laststep
-          )
-      ;;(setq b->ft (send *tfl* :lookup-transform "BODY" "rleg_end_coords" (send *msg* :header :stamp)))
-      (setq body->foot (send *tfl* :lookup-transform "BODY" end-coords (ros::time 0)))
-      (setq abc->foot (send odom-cds :transform body->foot))
-      (setq foot->laststep (send abc->foot :transformation (car (last (butlast steps)))))
-      ;;
-      (setq map->foot (send *tfl* :lookup-transform "map" end-coords (ros::time 0)))
-      (setq map->laststep (send map->foot :transform foot->laststep))
-      (pprint (list 'map->laststep map->laststep end-coords))
-      (pprint (list 'map->dest map->destination))
-      (setq coords-difference (send map->laststep :transformation map->destination))
-      (pprint (list 'diff coords-difference))
-      coords-difference
-      ))
-  )
-
-(defun check-footstep-collision
-  (current next)
-  ;; fix next footstep to avoid collision
-  ;; return original next footstep if current and next would not cause collision
-  (let (current-foot next-foot)
-    (setq current-foot (make-cube 235 135 20))
-    (setq next-foot (make-cube 235 135 20))
-    (send current-foot :move-to (send current :coords) :world)
-    (send next-foot :move-to (send next :coords) :world)
-    (let ((dy 0))
-      (while (pqp-collision-check-objects (list current-foot) (list next-foot))
-        (ros::ros-info "Collision detected between footsteps. Modify next step.")
-        ;;(pprint next-foot)
-        (cond
-         ((equal (send next :name) :lleg)
-          (setq dy (+ 1 dy))
-          (send next-foot :translate #f( 0 1 0) :local))
-         ((equal (send next :name) :rleg)
-          (setq dy (- dy 1))
-          (send next-foot :translate #f( 0 -1 0) :local))
-         )
-        )
-      (send next :translate (float-vector 0 dy 0 ) :local)
-      (pprint next)
-      )
-    )
-  next
-  )
-
-(defun refine-steps (remaining-steps &key (offset 2) (expand-step) (exec nil) (collision-avoid nil))
-  (let ((steps (butlast (car remaining-steps)))
-        (idx (cadr remaining-steps))
-        istep newsteps trans)
-    (setq istep (elt steps offset))
-    (setq steps (subseq steps (+ offset 1)))
-    (when expand-step
-      (let* ((last-cds (car (last steps)))
-             (trans (send last-cds :transformation
-                          (send (send last-cds :copy-worldcoords) :transform expand-step)
-                          :world))
-             (len (float (- (length steps) 2)))
-             (cntr 0))
-        (pprint (list 'trans trans expand-step))
-        (pprint (list 'org-steps steps))
-        (mapcar #'(lambda (s)
-                    (let ((tr (midcoords (/ cntr len) (make-coords) trans))
-                          nm)
-                      ;; limit trans
-                      #|
-                      (setq nm (norm (send tr :worldpos)))
-                      (when (> nm 15)
-                        (setq tr (midcoords (/ 15 nm) (make-coords) tr)))
-                      |#
-                      (send s :transform tr :world)
-                      (incf cntr)
-                      s)) (butlast steps))
-        (send last-cds :transform trans :world)
-        (pprint (list 'trans-steps steps))
-        ))
-    (when collision-avoid
-      (let ((start-time (ros::time-now))
-            fslist modifiedfs) ;; instant collision check
-        (push istep fslist)
-        (dotimes (cnt (length steps))
-          (if (eq cnt 0)
-              (setq modifiedfs (check-footstep-collision istep (elt steps cnt)))
-            (setq modifiedfs (check-footstep-collision (elt steps (- cnt 1)) (elt steps cnt))))
-          (push modifiedfs fslist)
-          )
-        (setq newsteps (reverse fslist))
-        (let ((now (ros::time-now)))
-          (ros::ros-info "took ~A sec for collision avoid"
-                  (send (ros::time- now start-time) :to-sec)))))
-    (unless collision-avoid
-      (setq newsteps (append (list istep) steps)))
-    (pprint (list 'new newsteps))
-    (when exec
-      (send *ri* :set-foot-steps-no-wait newsteps
-            :overwrite-footstep-index (+ idx offset 1)))
-    ))
-
+#|
 (setq *footsteps* nil)
 (defun execute-cb (server goal) ;; old version
   (ros::ros-info "execute-cb")
@@ -163,7 +40,7 @@
       (send *ri* :set-foot-steps-no-wait footstep-coords)
       (pprint footstep-coords)
 
-      (let (ret map-dest cds-diff wait-until odom-cds)
+      (let (ret map-dest cds-diff wait-until)
         (setq map-dest (copy-object (car (last footstep-coords))))
         (while
             (progn
@@ -171,10 +48,7 @@
               (car ret))
           (when *step-refine*
             ;;
-            (ros::spin-once)
-            (setq odom-cds (ros::tf-pose->coords (send (send *odom_msg* :pose) :pose)))
-
-            (setq cds-diff (calc-map-diff (car ret) map-dest odom-cds))
+            (setq cds-diff (step-error-on-map (car ret) map-dest))
 
             (when (and (> (length (car ret)) 6) ;; offset + 4
                        (or (not wait-until)
@@ -191,6 +65,7 @@
       ;;(send *ri* :set-gait-generator-param :default-orbit-type original-orbit-type)
       (send server :set-succeeded (send server :result))
       )))
+|#
 
 (setq *current-steps* nil)
 (setq *wait-until* nil)
@@ -219,47 +94,55 @@
     ;; TODO: check resume
     ;; get new goal
     (let* ((new-goal (server . ros::pending-goal))
+           (strategy (send new-goal :goal :strategy))
            (footstep-coords (footstep-array->coords (send new-goal :goal :footstep))))
-      (when *debug*
-        (pprint (list 'write *cntr*))
-        (dump-structure (format nil "/tmp/footstepmsg~2,2D.l" *cntr*) new-goal)
-        (incf *cntr*))
-      ;; TODO: check old-goal last = new-goal first
-      (setq *current-steps* (append-steps *current-steps* footstep-coords))
+      (cond
+       ((= strategy jsk_footstep_msgs::execfootstepsgoal::*RESUME*) ;; resume (append)
+        (when *debug*
+          (pprint (list 'write *cntr*))
+          (dump-structure (format nil "/tmp/footstepmsg~2,2D.l" *cntr*) new-goal)
+          (incf *cntr*))
+        ;; TODO: check old-goal last = new-goal first
+        (setq *current-steps* (append-steps *current-steps* footstep-coords))
 
-      (let* ((ret (send *ri* :get-remaining-foot-step-sequence-current-index))
-             (idx (cadr ret))
-             (abc-steps (butlast (car ret)))
-             (abc-last-foot (car (last abc-steps)))
-             abc-b-list
-             )
-        (unless (eq (send abc-last-foot :name)
-                    (send (car footstep-coords) :name))
-          (setq abc-last-foot (car (last (butlast abc-steps)))))
-        (setq abc-b-list
-              (mapcar #'(lambda (x)
-                          (let ((cds (send (send abc-last-foot :copy-worldcoords)
-                                           :transform (send (car footstep-coords) :transformation x)
-                                           )))
-                            (send cds :name (send x :name))
-                            cds))
-                      footstep-coords))
-        (setq abc-steps (append-steps abc-steps abc-b-list))
-        (let ((sending-steps (subseq abc-steps *appending-offset*)))
-          (send *ri* :set-foot-steps-no-wait sending-steps
-                :overwrite-footstep-index (+ idx *appending-offset* 1)))
-        (setq *wait-until* (+ idx *appending-offset* 1))
+        (let* ((ret (send *ri* :get-remaining-foot-step-sequence-current-index))
+               (idx (cadr ret))
+               (abc-steps (butlast (car ret)))
+               (abc-last-foot (car (last abc-steps)))
+               abc-b-list
+               )
+          (unless (eq (send abc-last-foot :name)
+                      (send (car footstep-coords) :name))
+            (setq abc-last-foot (car (last (butlast abc-steps)))))
+          (setq abc-b-list
+                (mapcar #'(lambda (x)
+                            (let ((cds (send (send abc-last-foot :copy-worldcoords)
+                                             :transform (send (car footstep-coords) :transformation x)
+                                             )))
+                              (send cds :name (send x :name))
+                              cds))
+                        footstep-coords))
+          (setq abc-steps (append-steps abc-steps abc-b-list))
+          (let ((sending-steps (subseq abc-steps *appending-offset*)))
+            (send *ri* :set-foot-steps-no-wait sending-steps
+                  :overwrite-footstep-index (+ idx *appending-offset* 1)))
+          (setq *wait-until* (+ idx *appending-offset* 1))
+          )
+        ;; dirty hack
+        (setq (server . ros::pending-goal) nil)
+        (setq (server . ros::status) actionlib_msgs::GoalStatus::*active*)
+        (setq (server . ros::goal) new-goal)
+        (setq (server . ros::goal-id) (send new-goal :goal_id))
+        (ros::ros-info "execute-cb: append steps ~D / total ~D steps"
+                       (length footstep-coords)
+                       (length *current-steps*))
+        (return-from execute-cb2)
         )
-      ;; dirty hack
-      (setq (server . ros::pending-goal) nil)
-      (setq (server . ros::status) actionlib_msgs::GoalStatus::*active*)
-      (setq (server . ros::goal) new-goal)
-      (setq (server . ros::goal-id) (send new-goal :goal_id))
-      (ros::ros-info "execute-cb: append steps ~D / total ~D steps"
-                     (length footstep-coords)
-                     (length *current-steps*))
-      (return-from execute-cb2))
-    )
+       ((= strategy jsk_footstep_msgs::execfootstepsgoal::*NEW_TARGET*) ;; new target (overwrite old one)
+        ;;
+        (return-from execute-cb2)
+        )
+       )))
   ;; check done
   (let ((ret (send *ri* :get-remaining-foot-step-sequence-current-index)))
     (unless (car ret)
@@ -278,9 +161,8 @@
 
       (setq ret (send *ri* :get-remaining-foot-step-sequence-current-index))
       (ros::spin-once)
-      (setq odom-cds (ros::tf-pose->coords (send (send *odom_msg* :pose) :pose)))
 
-      (setq cds-diff (calc-map-diff (car ret) map-dest odom-cds))
+      (setq cds-diff (calc-step-error-on-map (car ret) map-dest))
 
       (when (and (> (length (car ret)) 6) ;; offset + 4
                  (or (not *wait-until*)
@@ -293,9 +175,6 @@
         )
       ))
   )
-
-(defun abc_odom_callback (msg) (setq *odom_msg* msg))
-(ros::subscribe "/odom" nav_msgs::Odometry #'abc_odom_callback)
 
 (setq *server* (instance ros::simple-action-server :init
                          (ros::get-name)

--- a/jsk_footstep_controller/euslisp/util.l
+++ b/jsk_footstep_controller/euslisp/util.l
@@ -61,3 +61,225 @@ You can create `*ri*' like
     ;;(append now-steps2 next-steps2)
     (append (butlast now-steps) (cdr next-steps))
     )))
+
+(defun coords->ros-footstep (coords &key (leg))
+  (let ((footstep (instance jsk_footstep_msgs::Footstep :init)))
+    (send footstep :pose (ros::coords->tf-pose coords))
+    (unless leg
+      (setq leg (send coords :name))
+      (unless leg
+        (warn ";; :name or keyword leg should be set for footstep~%");
+        (return-from coords->ros-footstep)))
+    (cond
+     ((or (eq leg :lleg)
+          (eq leg :left)
+          (string= leg "lleg")
+          (string= leg "left"))
+      (setq leg jsk_footstep_msgs::Footstep::*LEFT*)
+      )
+     ((or (eq leg :rleg)
+          (eq leg :right)
+          (string= leg "rleg")
+          (string= leg "right"))
+      (setq leg jsk_footstep_msgs::Footstep::*RIGHT*)
+      )
+     (t
+      (warn "expected leg is :lleg, :rleg, :left and :right~%")
+      ))
+    (send footstep :leg leg)
+    footstep))
+
+(defun make-footsteps (steps &key (frame-id "map") (stamp (ros::time 0)))
+  (let ((footstep-list (instance jsk_footstep_msgs::FootstepArray :init)))
+    (send footstep-list :header :stamp stamp)
+    (send footstep-list :header :frame_id frame-id)
+    (send footstep-list :footsteps
+          (mapcar #'coords->ros-footstep steps))
+    footstep-list
+    ))
+
+(defun make-footstep-planning-msgs (start-coords target-coords
+                                    &key (frame-id "map") (stamp (ros::time 0))
+                                    (start-leg :lleg) (end-leg :lleg)
+                                    (lleg-offset (make-coords :pos (float-vector 0  100 0)))
+                                    (rleg-offset (make-coords :pos (float-vector 0 -100 0)))
+                                    (relative-target nil)
+                                    &allow-other-keys)
+  (let (lstart rstart
+        lgoal rgoal)
+    (cond
+     ((listp start-coords)
+      (setq lstart (car  start-coords)
+            rstart (cadr start-coords)))
+     (t
+      (setq lstart (send (send start-coords :copy-worldcoords)
+                         :transform lleg-offset))
+      (setq rstart (send (send start-coords :copy-worldcoords)
+                         :transform rleg-offset))
+      ))
+    (send lstart :name :lleg)
+    (send rstart :name :rleg)
+
+    (when (and relative-target (derivedp target-coords coordinates))
+      (let* ((midc (midcoords 0.5 rstart lstart)))
+        (send midc :transform target-coords)
+        (setq target-coords midc)
+        ))
+
+    (cond
+     ((listp target-coords)
+      (setq lgoal (car  target-coords)
+            rgoal (cadr target-coords)))
+     (t
+      (setq lgoal (send (send target-coords :copy-worldcoords)
+                        :transform lleg-offset))
+      (setq rgoal (send (send target-coords :copy-worldcoords)
+                        :transform rleg-offset))
+      ))
+    (send lgoal :name :lleg)
+    (send rgoal :name :rleg)
+
+    (let ((initial-steps (if (eq start-leg :lleg) (list lstart rstart) (list rstart lstart)))
+          (goal-steps    (if (eq end-leg :lleg)   (list lgoal rgoal) (list rgoal lgoal)))
+          (goal (instance jsk_footstep_msgs::PlanFootstepsActionGoal :init)))
+      (send goal :goal :initial_footstep
+            (make-footsteps initial-steps :frame-id frame-id :stamp stamp))
+      (send goal :goal :goal_footstep
+            (make-footsteps goal-steps :frame-id frame-id :stamp stamp))
+      goal)
+    ))
+
+(defun make-coords-footstep-planning-msgs (target-coords
+                                           &rest args
+                                           &key (frame-id "map") (stamp (ros::time 0))
+                                           (lleg-tf-name "lleg_end_coords")
+                                           (rleg-tf-name "rleg_end_coords")
+                                           &allow-other-keys)
+  (let ((lstart (send *tfl* :lookup-transform frame-id lleg-tf-name stamp))
+        (rstart (send *tfl* :lookup-transform frame-id rleg-tf-name stamp)))
+    (apply #'make-footstep-planning-msgs
+           (list lstart rstart) target-coords :frame-id frame-id :stamp stamp args)
+    ))
+(defun make-go-pos-planning-msgs (x y th &rest args)
+  (let* ((trans (make-coords :pos (float-vector (* x 1000) (* y 1000) 0))))
+    (send trans :rotate (deg2rad th) :z)
+    (apply #'make-coords-footstep-planning-msgs trans :relative-target t args)
+    ))
+
+(defun calc-step-error-on-map (steps map->destination
+                               &key (min-remaining-steps 2) (debug t))
+  (when (< (length steps) (max 2 min-remaining-steps))
+    #|
+    (let (support-leg map->ft end-coords)
+      (if (eq (send map->destination :name) :lleg)
+          (setq support-leg :lleg end-coords "lleg_end_coords")
+        (setq support-leg :rleg end-coords "rleg_end_coords"))
+      (setq map->ft (send *tfl* :lookup-transform "map" end-coords (ros::time 0)))
+      (setq coords-difference
+            (send map->ft :transformation map->destination))
+      )
+    |#
+    (return-from calc-step-error-on-map)
+    )
+  (let (foot->laststep
+        map->odom)
+    (setq map->odom (send *tfl* :lookup-transform "map" "odom" (ros::time 0)))
+    (setq map->laststep (send (send map->odom :copy-worldcoords) :transform
+                              (elt steps (- (length steps) 2))))
+    (setq coords-difference (send map->laststep :transformation map->destination))
+    (when debug
+      (pprint (list 'map->laststep map->laststep))
+      (pprint (list 'map->destination map->destination))
+      (pprint (list 'diff coords-difference)))
+    coords-difference
+    )
+  )
+
+(defun check-footstep-collision (current next &key (debug nil))
+  ;; fix next footstep to avoid collision
+  ;; return original next footstep if current and next would not cause collision
+  (let ((current-foot (make-cube 235 135 20))
+        (next-foot (make-cube 235 135 20)))
+
+    (send current-foot :move-to (send current :coords) :world)
+    (send next-foot :move-to (send next :coords) :world)
+    (let ((dy 0))
+      (while (pqp-collision-check-objects (list current-foot) (list next-foot))
+        (if debug (ros::ros-info "Collision detected between footsteps. Modify next step."))
+        ;;(pprint next-foot)
+        (cond
+         ((equal (send next :name) :lleg)
+          (setq dy (+ 1 dy))
+          (send next-foot :translate #f( 0 1 0) :local))
+         ((equal (send next :name) :rleg)
+          (setq dy (- dy 1))
+          (send next-foot :translate #f( 0 -1 0) :local))
+         )
+        )
+      (send next :translate (float-vector 0 dy 0 ) :local)
+      (if debug (pprint next))
+      )
+    )
+  next
+  )
+
+(defun refine-steps (remaining-steps
+                     &key (offset 2) (expand-step) (exec nil)
+                     (collision-avoid nil) (debug t))
+  (let ((steps (butlast (car remaining-steps)))
+        (idx (cadr remaining-steps))
+        istep newsteps trans)
+    (setq istep (elt steps offset))
+    (setq steps (subseq steps (+ offset 1)))
+    ;;
+    (when expand-step
+      (let* ((last-cds (car (last steps))) ;; coordinates of last step
+             (trans (send last-cds :transformation
+                          (send (send last-cds :copy-worldcoords) :transform expand-step)
+                          :world))
+             (len (float (- (length steps) 2)))
+             (cntr 0))
+        (when debug
+          (pprint (list 'trans trans expand-step))
+          (pprint (list 'org-steps steps)))
+        (mapcar #'(lambda (s)
+                    (let ((tr (midcoords (/ cntr len) (make-coords) trans))
+                          nm)
+                      ;; limit trans
+                      #|
+                      (setq nm (norm (send tr :worldpos)))
+                      (when (> nm 15)
+                        (setq tr (midcoords (/ 15 nm) (make-coords) tr)))
+                      |#
+                      (send s :transform tr :world)
+                      (incf cntr)
+                      s)) (butlast steps))
+        (send last-cds :transform trans :world)
+        (if debug (pprint (list 'trans-steps steps)))
+        ))
+    ;;
+    (cond
+     (collision-avoid
+      (let ((start-time (ros::time-now))
+            fslist modifiedfs) ;; instant collision check
+        (push istep fslist)
+        (dotimes (cnt (length steps))
+          (if (eq cnt 0)
+              (setq modifiedfs (check-footstep-collision istep (elt steps cnt)))
+            (setq modifiedfs (check-footstep-collision (elt steps (- cnt 1)) (elt steps cnt))))
+          (push modifiedfs fslist)
+          )
+        (setq newsteps (reverse fslist))
+        (when debug
+          (let ((now (ros::time-now)))
+            (ros::ros-info "took ~A sec for collision avoid"
+                           (send (ros::time- now start-time) :to-sec))))
+        ))
+     (t
+      (setq newsteps (append (list istep) steps))))
+
+    (if debug (pprint (list 'new newsteps)))
+    (when exec
+      (send *ri* :set-foot-steps-no-wait newsteps
+            :overwrite-footstep-index (+ idx offset 1)))
+    ))


### PR DESCRIPTION
footstepを使ってgo-posするためのサーバー/クライアントを作りました。
いずれfootstep_markerに統合を目指しています。

```go-pos-server.l``` でサーバーを立ち上げて、以下のようにclientを使います。
clientではgo-posで目的地を上書きするときは明示的にoverwriteをつけるようにしています。

~~~
(load "package://jsk_footstep_controller/euslisp/go-pos-client.l")
(setq *gp* (instance go-pos-client :init))
(send *gp* :go-pos-no-wait 2 0 0)
(send *gp* :go-pos-no-wait 2 1 0 :overwrite t)
~~~


