### PR TITLE
Use floor detection in footstep

### DIFF
--- a/jsk_footstep_controller/launch/floor_detection.launch
+++ b/jsk_footstep_controller/launch/floor_detection.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="fixed_frame_id" default="odom" />
+  <arg name="use_snapshot" default="true"/>
   <!-- <arg name="input_cloud" default="/accumulated_heightmap_pointcloud_static/output"/> -->
   <arg name="input_cloud" default="robot_center_pointcloud/output"/>
   <node pkg="jsk_topic_tools"
@@ -74,6 +75,8 @@
           - from: ~output
             to: /floor_coeffs
     </rosparam>
+    <remap from="floor_planar_segmentation/model" to="/floor_coeffs" unless="$(arg use_snapshot)"/>
+    <remap from="floor_plane_coefficients_snapshot/output" to="/floor_coeffs" if="$(arg use_snapshot)"/>
   </node>
   <rosparam param="floor_fixed_frame_pointcloud" subst_value="true">
     target_frame_id: $(arg fixed_frame_id)

--- a/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
+++ b/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
@@ -5,6 +5,7 @@
   <arg name="USE_NORMAL" default="false" />
   <arg name="use_footstep_marker" default="true"/>
   <arg name="use_go_pos_server" default="true"/>
+  <arg name="use_floor_detection" default="false"/>
 
   <arg if="$(arg USE_NORMAL)"     name="input_point_cloud"
        value="/footstep_normal_estimation/output_with_xyz" />
@@ -192,6 +193,10 @@
           args="$(find jsk_footstep_controller)/euslisp/go-pos-server.l"
           output="screen"/>
   </group>
+
+  <include file="$(find jsk_footstep_controller)/launch/floor_detection.launch" if="$(arg use_floor_detection)">
+    <arg name="use_snapshot" value="false"/>
+  </include>
 
   <node pkg="rviz" type="rviz" name="rviz" 
         args="-d $(find jsk_footstep_planner)/config/jaxon_footstep_planner_perception.rviz"


### PR DESCRIPTION
Add option arg to use floor_detection launch to compensate initial z errors from abc odom.
Default use_floor_detection option is false to make default behavior same as before.