### PR TITLE
Add plane projection option to go pos server

### DIFF
--- a/jsk_footstep_controller/euslisp/go-pos-server.l
+++ b/jsk_footstep_controller/euslisp/go-pos-server.l
@@ -1,5 +1,5 @@
 #!/usr/bin/env roseus
-
+(ros::roseus-add-msgs "jsk_recognition_msgs")
 (ros::roseus-add-msgs "jsk_footstep_msgs")
 (ros::roseus-add-msgs "jsk_footstep_controller")
 (load "package://jsk_footstep_controller/euslisp/util.l")
@@ -14,6 +14,7 @@
 (setq *replanning-translation-threshould* (ros::get-param "~/replanning_translation_threshold"))
 (unless (numberp *replanning-translation-threshould*)
   (setq *replanning-translation-threshould* 7.0))
+(setq *plane-projection* (ros::get-param "~/plane_projection" nil))
 
 ;;(setq *robot-name* (ros::get-param "/robot/type" (unix::getenv "ROBOT")))
 ;;(load (robot-interface-file *robot-name*))
@@ -40,6 +41,7 @@
   (setq *wait-until* nil)
   (setq *status* jsk_footstep_controller::GoPosFeedback::*WAITING*)
   (setq *previous-time* (ros::time-now))
+  (setq *planes* nil)
   )
 
 (defun publish-feedback (server &optional (steps -0))
@@ -48,6 +50,83 @@
     (send msg :feedback :remaining_steps steps)
     (send server :publish-feedback msg)
     ))
+
+(defun planes-cb (msg)
+  (let ((polygons (send msg :polygons)))
+    (let ((faces (mapcar #'(lambda (polygon)
+                             (let (trans)
+                               (send *tfl* :wait-for-transform (send polygon :header :frame_id) "map" (send polygon :header :stamp) 1)
+                               (setq trans (send *tfl* :lookup-transform
+                                                 (send polygon :header :frame_id)
+                                                 "map"
+                                                 (send polygon :header :stamp)))
+                               (if trans
+                                   (let ((points (mapcar #'(lambda (point)
+                                                             (send (send (send trans :copy-worldcoords)
+                                                                         :transform
+                                                                         (make-coords :pos (ros::tf-point->pos point)))
+                                                                   :worldpos))
+                                                         (send polygon :polygon :points))))
+                                     (instance face :init :vertices points))
+                                 nil
+                                 )
+                               )
+                             )
+                         polygons)))
+      (setq faces (remove-if #'null faces))
+      (if faces
+          (let ((fc (instance faceset :init :faces faces)))
+            (setq *planes* faces)
+            )))))
+
+(defun project-footsteps (footstep-coords)
+  (let (ret-coords projected-coords)
+    (if *planes*
+        (progn 
+          (setq projected-coords (mapcar #'(lambda (coords)
+                                             (let* ((candidates (project-coords-on-to-plane2 coords *planes* (float-vector 0 0 1)))
+                                                    (non-null-candidates (remove-if #'null candidates)) (ret nil))
+                                               ;; now only check distance for validity but rotation should be considered
+                                               (when (> (length non-null-candidates) 0)
+                                                 (dolist (c non-null-candidates)
+                                                   (if (> (norm (send (send coords :transformation c) :pos)) 100)
+                                                       (ros::ros-warn "projected footstep is too distant (~A [mm])" (norm (send (send coords :transformation c) :pos)))
+                                                     (if ret
+                                                         (when (> (norm (send (send coords :transformation ret) :pos))
+                                                                  (norm (send (send coords :transformation c) :pos))) ;; use nearest footcoords from original
+                                                           (setq ret c)
+                                                           (send ret :name (send coords :name))
+                                                           )
+                                                       (progn
+                                                         (setq ret c)
+                                                         (send ret :name (send coords :name)))
+                                                       )
+                                                     )
+                                                   )
+                                                 )
+                                               ret
+                                               )
+                                             )
+                                         footstep-coords))
+          (if (member nil projected-coords)
+              (progn 
+                (ros::ros-warn "footstep projection is failed")
+                (setq ret-coords footstep-coords))
+            (progn
+              (pprint "before projection:")
+              (print-readable-coords footstep-coords)
+              (pprint "after projection:")
+              (print-readable-coords projected-coords)
+              (setq ret-coords projected-coords))
+            )
+          )
+      (progn
+        (ros::ros-warn "plane is not subscribed")
+        (setq ret-coords footstep-coords))
+      )
+    ret-coords
+    )
+  )
 
 (defun execute-cb (server goal)
   (let (remaining-steps)
@@ -92,7 +171,12 @@
             (ros::publish *footstep-visualize-topic* result)
             ;; execute
             (let ((footstep-coords (footstep-array->coords result)))
+              ;; plane projection
+              (when *plane-projection*
+                (setq footstep-coords (project-footsteps footstep-coords))
+                )
               ;; debug
+              (pprint "new steps:")
               (print-readable-coords footstep-coords)
               (send *ri* :set-foot-steps-no-wait footstep-coords);; execute ...
               (setq *current-steps* footstep-coords)
@@ -280,6 +364,8 @@
     ))
 
 (defvar *tfl* (instance ros::transform-listener :init))
+(ros::subscribe (format nil "~A/planes" (ros::get-name)) jsk_recognition_msgs::PolygonArray #'planes-cb)
+
 (setq *planning-client*
       (instance ros::simple-action-client :init
                 "footstep_planner" jsk_footstep_msgs::PlanFootstepsAction))

--- a/jsk_footstep_controller/euslisp/go-pos-server.l
+++ b/jsk_footstep_controller/euslisp/go-pos-server.l
@@ -304,6 +304,10 @@
                                  (step-ary (footstep-array->coords result))
                                  send-steps)
                             (ros::publish *footstep-visualize-topic* result)
+                            ;; plane projection
+                            (when *plane-projection*
+                              (setq step-ary (project-footsteps step-ary))
+                              )
                             (setq send-steps (mapcar #'(lambda (x)
                                                          (let ((cds (send x :copy-worldcoords)))
                                                            (send cds :transform odom->map :world)

--- a/jsk_footstep_controller/euslisp/go-pos-server.l
+++ b/jsk_footstep_controller/euslisp/go-pos-server.l
@@ -15,6 +15,7 @@
 (unless (numberp *replanning-translation-threshould*)
   (setq *replanning-translation-threshould* 7.0))
 (setq *plane-projection* (ros::get-param "~/plane_projection" nil))
+(setq *wait-for-plane* t)
 
 ;;(setq *robot-name* (ros::get-param "/robot/type" (unix::getenv "ROBOT")))
 ;;(load (robot-interface-file *robot-name*))
@@ -81,6 +82,13 @@
 
 (defun project-footsteps (footstep-coords)
   (let (ret-coords projected-coords)
+    (when *wait-for-plane*
+      (ros::ros-warn "plane is not subscribed, wait for planes")
+      (while (not *planes*)
+        (ros::spin-once)
+        (ros::sleep)
+        )
+      )
     (if *planes*
         (progn 
           (setq projected-coords (mapcar #'(lambda (coords)

--- a/jsk_footstep_controller/euslisp/go-pos-server.l
+++ b/jsk_footstep_controller/euslisp/go-pos-server.l
@@ -80,62 +80,6 @@
             (setq *planes* faces)
             )))))
 
-(defun project-footsteps (footstep-coords)
-  (let (ret-coords projected-coords)
-    (when *wait-for-plane*
-      (ros::ros-warn "plane is not subscribed, wait for planes")
-      (while (not *planes*)
-        (ros::spin-once)
-        (ros::sleep)
-        )
-      )
-    (if *planes*
-        (progn 
-          (setq projected-coords (mapcar #'(lambda (coords)
-                                             (let* ((candidates (project-coords-on-to-plane2 coords *planes* (float-vector 0 0 1)))
-                                                    (non-null-candidates (remove-if #'null candidates)) (ret nil))
-                                               ;; now only check distance for validity but rotation should be considered
-                                               (when (> (length non-null-candidates) 0)
-                                                 (dolist (c non-null-candidates)
-                                                   (if (> (norm (send (send coords :transformation c) :pos)) 100)
-                                                       (ros::ros-warn "projected footstep is too distant (~A [mm])" (norm (send (send coords :transformation c) :pos)))
-                                                     (if ret
-                                                         (when (> (norm (send (send coords :transformation ret) :pos))
-                                                                  (norm (send (send coords :transformation c) :pos))) ;; use nearest footcoords from original
-                                                           (setq ret c)
-                                                           (send ret :name (send coords :name))
-                                                           )
-                                                       (progn
-                                                         (setq ret c)
-                                                         (send ret :name (send coords :name)))
-                                                       )
-                                                     )
-                                                   )
-                                                 )
-                                               ret
-                                               )
-                                             )
-                                         footstep-coords))
-          (if (member nil projected-coords)
-              (progn 
-                (ros::ros-warn "footstep projection is failed")
-                (setq ret-coords footstep-coords))
-            (progn
-              (pprint "before projection:")
-              (print-readable-coords footstep-coords)
-              (pprint "after projection:")
-              (print-readable-coords projected-coords)
-              (setq ret-coords projected-coords))
-            )
-          )
-      (progn
-        (ros::ros-warn "plane is not subscribed")
-        (setq ret-coords footstep-coords))
-      )
-    ret-coords
-    )
-  )
-
 (defun execute-cb (server goal)
   (let (remaining-steps)
 
@@ -181,7 +125,14 @@
             (let ((footstep-coords (footstep-array->coords result)))
               ;; plane projection
               (when *plane-projection*
-                (setq footstep-coords (project-footsteps footstep-coords))
+                (when *wait-for-plane*
+                  (ros::ros-warn "plane is not subscribed, wait for planes")
+                  (while (not *planes*)
+                    (ros::spin-once)
+                    (ros::sleep)
+                    )
+                  )
+                (setq footstep-coords (project-footsteps *planes* footstep-coords))
                 )
               ;; debug
               (pprint "new steps:")
@@ -306,7 +257,14 @@
                             (ros::publish *footstep-visualize-topic* result)
                             ;; plane projection
                             (when *plane-projection*
-                              (setq step-ary (project-footsteps step-ary))
+                              (when *wait-for-plane*
+                                (ros::ros-warn "plane is not subscribed, wait for planes")
+                                (while (not *planes*)
+                                  (ros::spin-once)
+                                  (ros::sleep)
+                                  )
+                                )
+                              (setq step-ary (project-footsteps *planes* step-ary))
                               )
                             (setq send-steps (mapcar #'(lambda (x)
                                                          (let ((cds (send x :copy-worldcoords)))

--- a/jsk_footstep_controller/euslisp/jaxon-footstep-controller.l
+++ b/jsk_footstep_controller/euslisp/jaxon-footstep-controller.l
@@ -3,6 +3,7 @@
 ;; The most simplest version to execute footsteps by :set-foot-steps
 ;; method and have actionlib server interface
 (ros::roseus "jaxon_footstep_controller" :anonymous nil)
+(ros::roseus-add-msgs "jsk_recognition_msgs")
 (ros::roseus-add-msgs "jsk_footstep_msgs")
 (ros::roseus-add-msgs "nav_msgs")
 
@@ -13,6 +14,38 @@
 (setq *robot-name* (ros::get-param "/robot/type" (unix::getenv "ROBOT")))
 (load (robot-interface-file *robot-name*))
 (init-robot-from-name *robot-name*)
+
+(setq *plane-projection* (ros::get-param "~/plane_projection" nil))
+(setq *planes* nil)
+(setq *wait-for-plane* t)
+
+(defun planes-cb (msg)
+  (let ((polygons (send msg :polygons)))
+    (let ((faces (mapcar #'(lambda (polygon)
+                             (let (trans)
+                               (send *tfl* :wait-for-transform (send polygon :header :frame_id) "map" (send polygon :header :stamp) 1)
+                               (setq trans (send *tfl* :lookup-transform
+                                                 (send polygon :header :frame_id)
+                                                 "map"
+                                                 (send polygon :header :stamp)))
+                               (if trans
+                                   (let ((points (mapcar #'(lambda (point)
+                                                             (send (send (send trans :copy-worldcoords)
+                                                                         :transform
+                                                                         (make-coords :pos (ros::tf-point->pos point)))
+                                                                   :worldpos))
+                                                         (send polygon :polygon :points))))
+                                     (instance face :init :vertices points))
+                                 nil
+                                 )
+                               )
+                             )
+                         polygons)))
+      (setq faces (remove-if #'null faces))
+      (if faces
+          (let ((fc (instance faceset :init :faces faces)))
+            (setq *planes* faces)
+            )))))
 
 (defun walking-pose (&key (real t) (height 40))
   (send *robot* :reset-manip-pose)
@@ -78,6 +111,17 @@
         (pprint (list 'write *cntr*))
         (dump-structure (format nil "/tmp/footstepmsg~2,2D.l" *cntr*) goal)
         (incf *cntr*))
+      (when *plane-projection*
+        (when *wait-for-plane*
+          (ros::ros-warn "plane is not subscribed, wait for planes")
+          (while (not *planes*)
+            (ros::spin-once)
+            (ros::sleep)
+            )
+          )
+        (setq footstep-coords (project-footsteps *planes* footstep-coords))
+        )
+      (pprint "new steps:")
       (print-readable-coords footstep-coords)
       (send *ri* :set-foot-steps-no-wait footstep-coords)
       (setq *current-steps* footstep-coords))
@@ -114,6 +158,10 @@
           (unless (eq (send abc-last-foot :name)
                       (send (car footstep-coords) :name))
             (setq abc-last-foot (car (last (butlast abc-steps)))))
+          (unless abc-last-foot
+            (ros::ros-info "execute-cb: abc-last-foot is nil")
+            (return-from execute-cb2)
+            )
           (setq abc-b-list
                 (mapcar #'(lambda (x)
                             (let ((cds (send (send abc-last-foot :copy-worldcoords)
@@ -124,6 +172,16 @@
                         footstep-coords))
           (setq abc-steps (append-steps abc-steps abc-b-list))
           (let ((sending-steps (subseq abc-steps *appending-offset*)))
+            (when *plane-projection*
+              (when *wait-for-plane*
+                (ros::ros-warn "plane is not subscribed, wait for planes")
+                (while (not *planes*)
+                  (ros::spin-once)
+                  (ros::sleep)
+                  )
+                )
+              (setq sending-steps (project-footsteps *planes* sending-steps))
+              )
             (send *ri* :set-foot-steps-no-wait sending-steps
                   :overwrite-footstep-index (+ idx *appending-offset* 1)))
           (setq *wait-until* (+ idx *appending-offset* 1))
@@ -176,6 +234,7 @@
       ))
   )
 
+(ros::subscribe (format nil "~A/planes" (ros::get-name)) jsk_recognition_msgs::PolygonArray #'planes-cb)
 (setq *server* (instance ros::simple-action-server :init
                          (ros::get-name)
                          jsk_footstep_msgs::ExecFootstepsAction

--- a/jsk_footstep_controller/euslisp/util.l
+++ b/jsk_footstep_controller/euslisp/util.l
@@ -283,3 +283,45 @@ You can create `*ri*' like
       (send *ri* :set-foot-steps-no-wait newsteps
             :overwrite-footstep-index (+ idx offset 1)))
     ))
+
+;; copied from obsoluted euslisp footstep planner: footstep_planner_util.l
+(defun project-coords-on-to-plane2 (coords planes z-axis)
+  (let ((point (send coords :worldpos)))
+    ;; first, creating line from the point and z-axis
+    ;; and, compute the points projected on the planes
+    ;; x = P + aZ: line
+    ;; nx + D = 0: plane
+    ;; n(P + aZ) + D = 0
+    ;; nP + anZ + D = 0
+    ;; anZ = -(D + nP)
+    ;; a = -(D + nP) / nZ
+    (let ((candidates (mapcar #'(lambda (pln)
+                                  (let ((projected-point
+                                         (let ((plane-normal (send pln :normal))
+                                               (plane-D (- (send pln :plane-distance (float-vector 0 0 0)))))
+                                           (let ((alpha (/ (- plane-D (v. plane-normal point))
+                                                           (v. plane-normal z-axis))))
+                                             (v+ point (scale alpha z-axis))))))
+                                    (if (not (eq (send pln :insidep projected-point) :outside))
+                                        (let* ((n (send pln :normal))
+                                               (nf (matrix-column
+                                                    (send (send coords :copy-worldcoords) :worldrot) 2)))
+                                          (if (< (v. nf n) 0)
+                                              (setq n (scale -1.0 n)))
+                                          (let ((ret (send coords :copy-worldcoords)))
+                                            (send ret :locate projected-point :world)
+                                            (if (eps= (norm (v* n nf)) 0)
+                                                ret
+                                              (let* ((b (v* nf n))
+                                                     (b* (normalize-vector b))
+                                                     (theta (asin (norm b))))
+                                                (send ret :rotate theta b* :world)
+                                                ret))
+                                            ret)))))
+                              planes)))
+      (let ((non-null-candidates (remove-if #'null candidates)))
+        (ros::ros-info "project coordinates to ~A planes" (length non-null-candidates))
+        (ros::ros-info "  ~A planes" (length planes))
+        (ros::ros-info "  ~A failed to project" (- (length candidates) (length non-null-candidates)))
+        (if non-null-candidates non-null-candidates ;car is not good
+          nil)))))

--- a/jsk_footstep_controller/euslisp/util.l
+++ b/jsk_footstep_controller/euslisp/util.l
@@ -325,3 +325,52 @@ You can create `*ri*' like
         (ros::ros-info "  ~A failed to project" (- (length candidates) (length non-null-candidates)))
         (if non-null-candidates non-null-candidates ;car is not good
           nil)))))
+
+(defun project-footsteps (planes footstep-coords)
+  (let (ret-coords projected-coords)    
+    (if planes
+        (progn 
+          (setq projected-coords (mapcar #'(lambda (coords)
+                                             (let* ((candidates (project-coords-on-to-plane2 coords planes (float-vector 0 0 1)))
+                                                    (non-null-candidates (remove-if #'null candidates)) (ret nil))
+                                               ;; now only check distance for validity but rotation should be considered
+                                               (when (> (length non-null-candidates) 0)
+                                                 (dolist (c non-null-candidates)
+                                                   (if (> (norm (send (send coords :transformation c) :pos)) 100)
+                                                       (ros::ros-warn "projected footstep is too distant (~A [mm])" (norm (send (send coords :transformation c) :pos)))
+                                                     (if ret
+                                                         (when (> (norm (send (send coords :transformation ret) :pos))
+                                                                  (norm (send (send coords :transformation c) :pos))) ;; use nearest footcoords from original
+                                                           (setq ret c)
+                                                           (send ret :name (send coords :name))
+                                                           )
+                                                       (progn
+                                                         (setq ret c)
+                                                         (send ret :name (send coords :name)))
+                                                       )
+                                                     )
+                                                   )
+                                                 )
+                                               ret
+                                               )
+                                             )
+                                         footstep-coords))
+          (if (member nil projected-coords)
+              (progn 
+                (ros::ros-warn "footstep projection is failed")
+                (setq ret-coords footstep-coords))
+            (progn
+              (pprint "before projection:")
+              (print-readable-coords footstep-coords)
+              (pprint "after projection:")
+              (print-readable-coords projected-coords)
+              (setq ret-coords projected-coords))
+            )
+          )
+      (progn
+        (ros::ros-warn "plane is not subscribed")
+        (setq ret-coords footstep-coords))
+      )
+    ret-coords
+    )
+  )

--- a/jsk_footstep_controller/launch/floor_detection.launch
+++ b/jsk_footstep_controller/launch/floor_detection.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="fixed_frame_id" default="odom" />
+  <arg name="use_snapshot" default="true"/>
   <!-- <arg name="input_cloud" default="/accumulated_heightmap_pointcloud_static/output"/> -->
   <arg name="input_cloud" default="robot_center_pointcloud/output"/>
   <node pkg="jsk_topic_tools"
@@ -74,6 +75,8 @@
           - from: ~output
             to: /floor_coeffs
     </rosparam>
+    <remap from="floor_planar_segmentation/model" to="/floor_coeffs" unless="$(arg use_snapshot)"/>
+    <remap from="floor_plane_coefficients_snapshot/output" to="/floor_coeffs" if="$(arg use_snapshot)"/>
   </node>
   <rosparam param="floor_fixed_frame_pointcloud" subst_value="true">
     target_frame_id: $(arg fixed_frame_id)

--- a/jsk_footstep_controller/launch/floor_detection.launch
+++ b/jsk_footstep_controller/launch/floor_detection.launch
@@ -14,25 +14,11 @@
         remappings:
           - from: ~input
             to: $(arg input_cloud)
-      - name: floor_laser_x_filter
-        type: pcl/PassThrough
-        remappings:
-          - from: ~input
-            to: floor_fixed_frame_pointcloud/output
-          - from: /tf
-            to: /tf_null
-      - name: floor_laser_y_filter
-        type: pcl/PassThrough
-        remappings:
-          - from: ~input
-            to: floor_laser_x_filter/output
-          - from: /tf
-            to: /tf_null
       - name: floor_laser_z_filter
         type: pcl/PassThrough
         remappings:
           - from: ~input
-            to: floor_laser_y_filter/output
+            to: floor_fixed_frame_pointcloud/output
           - from: /tf
             to: /tf_null
       - name: floor_voxel_grid
@@ -81,20 +67,6 @@
   <rosparam param="floor_fixed_frame_pointcloud" subst_value="true">
     target_frame_id: $(arg fixed_frame_id)
   </rosparam>
-  <group ns="floor_laser_x_filter">
-    <rosparam>
-      filter_field_name: x
-      filter_limit_min: -5.0
-      filter_limit_max: 1000.0
-    </rosparam>
-  </group>
-  <group ns="floor_laser_y_filter">
-    <rosparam>
-      filter_field_name: y
-      filter_limit_min: -5.0
-      filter_limit_max: 5.0
-    </rosparam>
-  </group>
   <group ns="floor_laser_z_filter">
     <rosparam>
       filter_field_name: z

--- a/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
+++ b/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
@@ -5,6 +5,7 @@
   <arg name="USE_NORMAL" default="false" />
   <arg name="use_footstep_marker" default="true"/>
   <arg name="use_go_pos_server" default="true"/>
+  <arg name="use_floor_detection" default="false"/>
 
   <arg if="$(arg USE_NORMAL)"     name="input_point_cloud"
        value="/footstep_normal_estimation/output_with_xyz" />
@@ -194,6 +195,10 @@
       <param name="force_replanning" value="false" />
     </node>
   </group>
+
+  <include file="$(find jsk_footstep_controller)/launch/floor_detection.launch" if="$(arg use_floor_detection)">
+    <arg name="use_snapshot" value="false"/>
+  </include>
 
   <node pkg="rviz" type="rviz" name="rviz" 
         args="-d $(find jsk_footstep_planner)/config/jaxon_footstep_planner_perception.rviz"

--- a/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
+++ b/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
@@ -194,7 +194,7 @@
           args="$(find jsk_footstep_controller)/euslisp/go-pos-server.l"
           output="screen">
       <param name="force_replanning" value="false" />
-      <param name="plane_projection" value="true"/>
+      <param name="plane_projection" value="$(arg use_footstep_plane_detection)"/>
       <remap from="~planes" to="/footstep_plane_plane_rejector/output_polygons"/>
     </node>
   </group>

--- a/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
+++ b/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
@@ -193,6 +193,8 @@
           args="$(find jsk_footstep_controller)/euslisp/go-pos-server.l"
           output="screen">
       <param name="force_replanning" value="false" />
+      <param name="plane_projection" value="true"/>
+      <remap from="~planes" to="/plane_detection/plane_rejector/output_polygons"/>
     </node>
   </group>
 

--- a/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
+++ b/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
@@ -6,6 +6,7 @@
   <arg name="use_footstep_marker" default="true"/>
   <arg name="use_go_pos_server" default="true"/>
   <arg name="use_floor_detection" default="false"/>
+  <arg name="use_footstep_plane_detection" default="false"/>
 
   <arg if="$(arg USE_NORMAL)"     name="input_point_cloud"
        value="/footstep_normal_estimation/output_with_xyz" />
@@ -194,9 +195,14 @@
           output="screen">
       <param name="force_replanning" value="false" />
       <param name="plane_projection" value="true"/>
-      <remap from="~planes" to="/plane_detection/plane_rejector/output_polygons"/>
+      <remap from="~planes" to="/footstep_plane_plane_rejector/output_polygons"/>
     </node>
   </group>
+
+  <include file="$(find jsk_footstep_planner)/launch/footstep_plane_detection.launch" if="$(arg use_footstep_plane_detection)">
+    <arg name="input_cloud" value="/accumulated_heightmap_pointcloud_static/output" />
+    <arg name="fixed_frame_id" value="map" />
+  </include>
 
   <include file="$(find jsk_footstep_controller)/launch/floor_detection.launch" if="$(arg use_floor_detection)">
     <arg name="use_snapshot" value="false"/>

--- a/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
+++ b/jsk_footstep_planner/launch/JAXON_RED_footstep_planner_perception.launch
@@ -183,6 +183,8 @@
     <node pkg="jsk_footstep_controller" type="jaxon-footstep-controller.l" name="jaxon_footstep_controller"
           output="screen">
       <param name="use_step_refine" value="true" />
+      <param name="plane_projection" value="$(arg use_footstep_plane_detection)"/>
+      <remap from="~planes" to="/footstep_plane_plane_rejector/output_polygons"/>
     </node>
     <include file="$(find jsk_teleop_joy)/launch/joy_footstep_marker.launch" if="$(arg use_joy)">
       <arg name="CONTROLLER_DEV" value="$(arg joy_dev)"/>

--- a/jsk_footstep_planner/launch/footstep_plane_detection.launch
+++ b/jsk_footstep_planner/launch/footstep_plane_detection.launch
@@ -56,7 +56,7 @@
     </group>
     <group ns="footstep_plane_odom_laser">
       <rosparam subst_value="true">
-        target_frame_id: ground
+        target_frame_id: $(arg fixed_frame_id)
         use_multithread_callback: $(arg USE_MULTITHREAD_CALLBACK)
       </rosparam>
     </group>

--- a/jsk_footstep_planner/launch/footstep_plane_detection.launch
+++ b/jsk_footstep_planner/launch/footstep_plane_detection.launch
@@ -1,0 +1,88 @@
+<launch>
+  <arg name="input_cloud" default="/accumulated_heightmap_pointcloud_static/output" />
+  <arg name="fixed_frame_id" default="map" />
+  <arg name="resolution" default="0.01" />
+  <arg name="SIMULATION" default="false" />
+  <arg unless="$(arg SIMULATION)" name="USE_MULTITHREAD_CALLBACK" value="true" />
+  <arg unless="$(arg SIMULATION)" name="NUM_OF_THREAD_OMP"    value="0" />
+  <arg if="$(arg SIMULATION)" name="USE_MULTITHREAD_CALLBACK" value="false" />
+  <arg if="$(arg SIMULATION)" name="NUM_OF_THREAD_OMP" value="1" />
+  
+  <node pkg="jsk_topic_tools"
+        type="standalone_complexed_nodelet"
+        name="footstep_plane_detection_manager"
+        output="screen">
+    <rosparam subst_value="true">
+    nodelets:
+      - name: footstep_plane_octree_voxel_grid
+        type: jsk_pcl/OctreeVoxelGrid
+        remappings:
+          - from: ~input
+            to: $(arg input_cloud)
+      - name: footstep_plane_odom_laser
+        type: jsk_pcl/TfTransformCloud
+        remappings:
+          - from: ~input
+            to: footstep_plane_octree_voxel_grid/output
+      - name: footstep_plane_normal_estimation
+        type: jsk_pcl/NormalEstimationOMP
+        remappings:
+          - from: ~input
+            to: footstep_plane_odom_laser/output
+      - name: footstep_plane_region_growing_multiple_plane_segmentation
+        type: jsk_pcl/RegionGrowingMultiplePlaneSegmentation
+        remappings:
+          - from: ~input
+            to: footstep_plane_normal_estimation/output_with_xyz
+          - from: ~input_normal
+            to: footstep_plane_normal_estimation/output_with_xyz
+      - name: footstep_plane_plane_rejector
+        type: jsk_pcl/PlaneRejector
+        remappings:
+          - from: ~input_polygons
+            to: footstep_plane_region_growing_multiple_plane_segmentation/output/polygons
+          - from: ~input_coefficients
+            to: footstep_plane_region_growing_multiple_plane_segmentation/output/coefficients
+          - from: ~input_inliers
+            to: footstep_plane_region_growing_multiple_plane_segmentation/output/inliers
+    </rosparam>
+  </node>
+
+    <group ns="footstep_plane_octree_voxel_grid">
+      <rosparam subst_value="true">
+        resolution: $(arg resolution)
+        use_multithread_callback: $(arg USE_MULTITHREAD_CALLBACK)
+      </rosparam>
+    </group>
+    <group ns="footstep_plane_odom_laser">
+      <rosparam subst_value="true">
+        target_frame_id: ground
+        use_multithread_callback: $(arg USE_MULTITHREAD_CALLBACK)
+      </rosparam>
+    </group>
+    <group ns="footstep_plane_normal_estimation">
+      <rosparam subst_value="true">
+        k_search: 50
+        use_multithread_callback: $(arg USE_MULTITHREAD_CALLBACK)
+        number_of_threads: $(arg NUM_OF_THREAD_OMP)
+      </rosparam>
+    </group>
+    <group ns="footstep_plane_region_growing_multiple_plane_segmentation">
+      <rosparam subst_value="true">
+        distance_threshold: 0.05
+        min_area: 0.01
+        max_area: 100.0
+        use_multithread_callback: $(arg USE_MULTITHREAD_CALLBACK)
+      </rosparam>
+    </group>
+    <group ns="footstep_plane_plane_rejector">
+      <rosparam subst_value="true">
+        processing_frame_id: $(arg fixed_frame_id)
+        reference_axis: [0, 0, 1]
+        angle: 0.0
+        use_inliers: true
+        allow_flip: true
+      </rosparam>
+    </group>
+
+</launch>


### PR DESCRIPTION
This PR includes #629.
To deal with unstable footstep execution problem on the horizontal plane temporaly, run global plane estimation and project planned footprints onto them before :set-foot-steps.
This projection may work in terrain walking but it is only checked in horizontal plane walking.
Default behavior is not changed.
(This problem should be solved by localization or pointcloud accumulation layer but I cannot solve it by instant methods like using raw imu orientation, faster executing rate, filtering, matching points before accumulation and so on.)