### PR TITLE
Migrate srv files from jsk_pcl_ros to jsk_recognition_msgs

### DIFF
--- a/jsk_footstep_planner/euslisp/footstep_planner_util.l
+++ b/jsk_footstep_planner/euslisp/footstep_planner_util.l
@@ -1,7 +1,6 @@
 ;; utility function for footstep planning
 (ros::roseus-add-msgs "jsk_footstep_msgs")
 (ros::roseus-add-msgs "jsk_recognition_msgs")
-(ros::roseus-add-srvs "jsk_pcl_ros")
 
 (defun project-coords-on-to-plane (coords planes z-axis)
   "z-axis is dummy parameter.
@@ -82,7 +81,7 @@
 (defun face-on-faces (f support-faces)
   (if *use-env-server*
       (progn
-        (let ((req (instance jsk_pcl_ros::PolygonOnEnvironmentRequest :init)))
+        (let ((req (instance jsk_recognition_msgs::PolygonOnEnvironmentRequest :init)))
           ;;(send req :environment_id *env-id*)
           (send req :environment_id 0)
           ;; build polygon samped

--- a/jsk_footstep_planner/euslisp/robot-model-util.l
+++ b/jsk_footstep_planner/euslisp/robot-model-util.l
@@ -1,7 +1,7 @@
 ;; Extend robot interface 
 
 (ros::roseus-add-msgs "jsk_footstep_msgs")
-(ros::roseus-add-srvs "jsk_pcl_ros")
+(ros::roseus-add-srvs "jsk_recognition_msgs")
 
 (ros::advertise "/robot_footstep" jsk_footstep_msgs::FootstepArray)
 
@@ -42,7 +42,7 @@
       msg))
   (:snap-footsteps (foot-coords &key
                                 (service "/locomotion/snapit/align_footstep"))
-    (let ((req (instance jsk_pcl_ros::SnapFootstepRequest :init)))
+    (let ((req (instance jsk_recognition_msgs::SnapFootstepRequest :init)))
       (send req :input (send self :footstep-to-rosmsg foot-coords))
       (let ((res (ros::service-call service req t)))
         (if res

--- a/jsk_footstep_planner/package.xml
+++ b/jsk_footstep_planner/package.xml
@@ -19,6 +19,8 @@
   <build_depend>jsk_recognition_utils</build_depend>
   <run_depend>jsk_recognition_utils</run_depend>
 
+  <run_depend>jsk_recognition_msgs</run_depend>
+
   <run_depend>roseus</run_depend>
 
   <build_depend>jsk_rviz_plugins</build_depend>


### PR DESCRIPTION
## Background

Some packages in jsk_visualization depends on jsk_pcl_ros because it uses the srv files.
But jsk_pcl_ros is a very large package and the dependency should be avoided ideally.
The solution is placing `msg/srv` files into `jsk_recognition_msgs`.

## Plans

1. Merge this after `jsk_recognition_msgs` is released: http://repositories.ros.org/status_page/ros_indigo_default.html?q=jsk_recognition_msgs
1. Release this pacakge.
1. Remove `jsk_pcl_ros/srv`.
1. Release `jsk_pcl_ros`.

## Related PRs

- https://github.com/jsk-ros-pkg/jsk_recognition/pull/1827
- https://github.com/jsk-ros-pkg/jsk_recognition/pull/1914