### PR TITLE
Add test for fs successor

### DIFF
--- a/jsk_footstep_planner/config/sample_robot_footstep_planner_params.yaml
+++ b/jsk_footstep_planner/config/sample_robot_footstep_planner_params.yaml
@@ -1,0 +1,175 @@
+# This is generated from (gen-all-footstep-planner-parameter-string *robot*).
+default_lfoot_to_rfoot_offset: [0.0, -0.15, 0.0]
+footstep_size_x: 0.2032
+footstep_size_y: 0.1016
+# please comment in after https://github.com/jsk-ros-pkg/jsk_control/issues/650 is solved.
+#rleg_footstep_offset: [0.05, 0.0, 0.0]
+#lleg_footstep_offset: [0.05, 0.0, 0.0]
+collision_bbox_size: [0.2032, 0.254, 0.90979]
+collision_bbox_offset: [0.05, 0.0, 0.0]
+successors:
+  - x: 0.1
+    y: 0.05
+    theta: 0.349066
+  - x: 0.1
+    y: 0.05
+    theta: 0.174533
+  - x: 0.1
+    y: 0.05
+    theta: 0.0
+  - x: 0.1
+    y: 0.05
+    theta: -0.174533
+  - x: 0.1
+    y: 0.05
+    theta: -0.349066
+  - x: 0.05
+    y: 0.1
+    theta: 0.349066
+  - x: 0.05
+    y: 0.1
+    theta: 0.174533
+  - x: 0.05
+    y: 0.1
+    theta: 0.0
+  - x: 0.05
+    y: 0.1
+    theta: -0.174533
+  - x: 0.05
+    y: 0.1
+    theta: -0.349066
+  - x: 0.05
+    y: 0.05
+    theta: 0.349066
+  - x: 0.05
+    y: 0.05
+    theta: 0.174533
+  - x: 0.05
+    y: 0.05
+    theta: 0.0
+  - x: 0.05
+    y: 0.05
+    theta: -0.174533
+  - x: 0.05
+    y: 0.05
+    theta: -0.349066
+  - x: 0.05
+    y: 0.0
+    theta: 0.349066
+  - x: 0.05
+    y: 0.0
+    theta: 0.174533
+  - x: 0.05
+    y: 0.0
+    theta: 0.0
+  - x: 0.05
+    y: 0.0
+    theta: -0.174533
+  - x: 0.05
+    y: 0.0
+    theta: -0.349066
+  - x: 0.0
+    y: 0.1
+    theta: 0.349066
+  - x: 0.0
+    y: 0.1
+    theta: 0.174533
+  - x: 0.0
+    y: 0.1
+    theta: 0.0
+  - x: 0.0
+    y: 0.1
+    theta: -0.174533
+  - x: 0.0
+    y: 0.1
+    theta: -0.349066
+  - x: 0.0
+    y: 0.05
+    theta: 0.349066
+  - x: 0.0
+    y: 0.05
+    theta: 0.174533
+  - x: 0.0
+    y: 0.05
+    theta: 0.0
+  - x: 0.0
+    y: 0.05
+    theta: -0.174533
+  - x: 0.0
+    y: 0.05
+    theta: -0.349066
+  - x: 0.0
+    y: 0.0
+    theta: 0.349066
+  - x: 0.0
+    y: 0.0
+    theta: 0.174533
+  - x: 0.0
+    y: 0.0
+    theta: 0.0
+  - x: 0.0
+    y: 0.0
+    theta: -0.174533
+  - x: 0.0
+    y: 0.0
+    theta: -0.349066
+  - x: -0.05
+    y: 0.1
+    theta: 0.349066
+  - x: -0.05
+    y: 0.1
+    theta: 0.174533
+  - x: -0.05
+    y: 0.1
+    theta: 0.0
+  - x: -0.05
+    y: 0.1
+    theta: -0.174533
+  - x: -0.05
+    y: 0.1
+    theta: -0.349066
+  - x: -0.05
+    y: 0.05
+    theta: 0.349066
+  - x: -0.05
+    y: 0.05
+    theta: 0.174533
+  - x: -0.05
+    y: 0.05
+    theta: 0.0
+  - x: -0.05
+    y: 0.05
+    theta: -0.174533
+  - x: -0.05
+    y: 0.05
+    theta: -0.349066
+  - x: -0.05
+    y: 0.0
+    theta: 0.349066
+  - x: -0.05
+    y: 0.0
+    theta: 0.174533
+  - x: -0.05
+    y: 0.0
+    theta: 0.0
+  - x: -0.05
+    y: 0.0
+    theta: -0.174533
+  - x: -0.05
+    y: 0.0
+    theta: -0.349066
+  - x: -0.1
+    y: 0.05
+    theta: 0.349066
+  - x: -0.1
+    y: 0.05
+    theta: 0.174533
+  - x: -0.1
+    y: 0.05
+    theta: 0.0
+  - x: -0.1
+    y: 0.05
+    theta: -0.174533
+  - x: -0.1
+    y: 0.05
+    theta: -0.349066

--- a/jsk_footstep_planner/euslisp/generate-footstep-planner-parameters-from-robot-model.l
+++ b/jsk_footstep_planner/euslisp/generate-footstep-planner-parameters-from-robot-model.l
@@ -151,4 +151,9 @@
 (setq *robot* *hrp2jsknt*)
 (objects (list *robot*))
 ;(gen-all-footstep-planner-parameter-string *robot*)
+
+(load "irteus/demo/sample-robot-model.l")
+(setq *robot* (instance sample-robot :init))
+(objects (list *robot*))
+(gen-all-footstep-planner-parameter-string *robot*)
 |#

--- a/jsk_footstep_planner/test/test_footstep_planning_eus_client.l
+++ b/jsk_footstep_planner/test/test_footstep_planning_eus_client.l
@@ -49,5 +49,49 @@
          (and result (footstep-array->coords result))
          )))))
 
+;; Test for problem https://github.com/jsk-ros-pkg/jsk_control/issues/650
+(deftest test-sample-footstep-successors
+  (assert
+   (progn
+     ;; Generate robot model
+     (let ((robot-name (ros::get-param "robot/type")))
+       (warn ";; ROBOT=~A~%" robot-name)
+       (cond
+        ((string= robot-name "HRP2JSKNTS")
+         (load "package://hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknts-interface.l")
+         (hrp2jsknts)
+         (setq *robot* *hrp2jsknts*))
+        ((string= robot-name "sample_robot")
+         (load "irteus/demo/sample-robot-model.l")
+         (setq *robot* (instance sample-robot :init))
+         (objects (list *robot*)))
+        (t)))
+     (if (not (boundp '*robot*))
+         ;; Currently, if no robot is specified, omit this sample
+         t
+       ;; Get successors (consider default_lfoot_to_rfoot_offset from :default-half-offset)
+       (let* ((offset (* 2 (elt (cadr (memq :default-half-offset (send *robot* :footstep-parameter))) 1)))
+              (successors (mapcar #'(lambda (ss)
+                                      (float-vector (* 1e3 (cdr (assoc "x" ss :test #'string=))) (+ (- offset) (* 1e3 (cdr (assoc "y" ss :test #'string=))))))
+                                  (ros::get-param "/footstep_planner/successors"))))
+         ;; Footstep plan
+         (publish-footstep-planning-obstacle-model-from-eus-pointcloud (instance pointcloud :init))
+         (let* ((result (plan-footstep-from-goal-coords (make-coords :pos (float-vector 600 -200 0) :rpy (list (deg2rad 45) 0 0)) :robot *robot*))
+                (result-footstep (footstep-array->coords result))
+                (footstep-dif-list
+                 (mapcar #'(lambda (fs0 fs1)
+                             (let ((tmp (subseq (send (send fs0 :transformation fs1) :worldpos) 0 2))) ;; (float-vector x y)
+                               (if (eq (send fs0 :name) :lleg)
+                                   tmp
+                                 (float-vector (elt tmp 0) (- (elt tmp 1)))))) ;; If rleg -> lleg, revert y component
+                         (butlast result-footstep) (cdr result-footstep)))
+                (ret
+                 ;; Check difference between footstep results and successors
+                 (mapcar #'(lambda (dif) (null (null (member dif successors :test #'(lambda (x y) (< (distance x y) 1e-1))))))
+                         (butlast footstep-dif-list 2)))) ;; Last 2 elements are finalize footsteps, which does not equal to successors
+           (warn ";; ret = ~A (~A)~%" (every #'identity ret) ret)
+           (every #'identity ret)
+           ))))))
+
 (run-all-tests)
 (exit 0)

--- a/jsk_footstep_planner/test/test_footstep_planning_eus_client.test
+++ b/jsk_footstep_planner/test/test_footstep_planning_eus_client.test
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="ROBOT" default="JAXON_RED"/>
+  <arg name="ROBOT" default="sample_robot"/>
   <arg name="USE_RVIZ" default="false"/>
   <include file="$(find jsk_footstep_planner)/launch/cppplanner/optimistic_footstep_planner.launch">
     <arg name="USE_SIMPLE_FOOTSTEP_CONTROLLER" value="true"/>
@@ -10,5 +10,6 @@
     <arg name="USE_RVIZ" value="$(arg USE_RVIZ)"/>
     <arg name="ROBOT" value="$(arg ROBOT)"/>
   </include>
+  <rosparam param="robot/type" subst_value="True">$(arg ROBOT)</rosparam>
   <test test-name="test_footstep_planning_eus_client" pkg="jsk_footstep_planner" type="test_footstep_planning_eus_client.l" time-limit="60.0"/>
 </launch>


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_control/issues/650
をテストするためのサンプル関数をテスト関数に追加しました。
また、eusのsample-robotをテストとして使用するようにしました。
デフォルトは、自動生成footstep parameterから問題の箇所をコメントアウトしたものをコミットしています。
なので、テストは通ります。
```
# please comment in after https://github.com/jsk-ros-pkg/jsk_control/issues/650 is solved.
#rleg_footstep_offset: [0.05, 0.0, 0.0]
#lleg_footstep_offset: [0.05, 0.0, 0.0]
```