### PR TITLE
[eus_qp] add rotational sliding constraint

### DIFF
--- a/eus_qp/euslisp/contact-optimization.l
+++ b/eus_qp/euslisp/contact-optimization.l
@@ -992,7 +992,7 @@
   "Calc conatraint param list for translational sliding.
    mu-trans is friction coefficient.
    norm-axis is axis of normal (such as fz).
-   slide-axis is axis of sliding direction (such as fx or fy)."
+   slide-axis is axis of sliding direction (such as x or y)."
   (let ((ret (mapcar #'(lambda (x) (make-list 6 :initial-element 0)) '(0 1)))
         (norm-idx (force-axis->index norm-axis))
         (slide-idx (axis->index slide-axis))

--- a/eus_qp/euslisp/contact-optimization.l
+++ b/eus_qp/euslisp/contact-optimization.l
@@ -698,10 +698,12 @@
          (append
           (list
            ;; friction
-           (if slide-axis
+           (if (or (equal slide-axis :x) (equal slide-axis :-x) (equal slide-axis :y) (equal slide-axis :-y))
                (instance 2D-translational-sliding-contact-constraint :init (* mu-margin-ratio mu-trans) :slide-axis slide-axis)
              (instance 2D-translational-friction-contact-constraint :init (* mu-margin-ratio mu-trans)))
-           (instance rotational-friction-contact-constraint :init (* mu-margin-ratio mu-rot) :fz)
+           (if (or (equal slide-axis :yaw) (equal slide-axis :-yaw))
+               (instance rotational-sliding-contact-constraint :init (* mu-margin-ratio mu-rot) :fz :slide-axis (case slide-axis (:yaw :z) (:-yaw :-z)))
+             (instance rotational-friction-contact-constraint :init (* mu-margin-ratio mu-rot) :fz))
            ;; cop
            (if contact-face
                (instance polygon-cop-contact-constraint :init contact-face)

--- a/eus_qp/euslisp/contact-optimization.l
+++ b/eus_qp/euslisp/contact-optimization.l
@@ -656,6 +656,25 @@
    )
   )
 
+(defclass rotational-sliding-contact-constraint
+  :super contact-constraint
+  :slots (mu-rot norm-axis slide-axis)
+  )
+
+(defmethod rotational-sliding-contact-constraint
+  (:init
+   (tmp-mu-rot tmp-norm-axis &key ((:slide-axis tmp-slide-axis) :z))
+   "Calc conatraint param list for rotational friction.
+   mu-rot is friction coefficient.
+   norm-axis is axis of normal (such as fz).
+   slide-axis is axis with sign of sliding direction (such as z or -z)."
+   (setq mu-rot tmp-mu-rot norm-axis tmp-norm-axis slide-axis tmp-slide-axis)
+   (setq constraint-param-list
+         (calc-constraint-param-list-for-rotational-sliding
+          mu-rot norm-axis slide-axis))
+   (send-super :init))
+  )
+
 (defclass default-contact-constraint
   :super contact-constraint
   :slots ()
@@ -1000,6 +1019,28 @@
         )
     (setf (elt (car ret) norm-idx) mu-trans)
     (setf (elt (cadr ret) norm-idx) (- mu-trans))
+    (cond ((> slide-sgn 0)
+           (setf (elt (car ret) slide-idx) 1)
+           (setf (elt (cadr ret) slide-idx) -1))
+          ((< slide-sgn 0)
+           (setf (elt (car ret) slide-idx) -1)
+           (setf (elt (cadr ret) slide-idx) 1)))
+    (list :matrix ret :vector (list 0 0))
+    ))
+
+(defun calc-constraint-param-list-for-rotational-sliding
+  (mu-rot norm-axis slide-axis)
+  "Calc conatraint param list for rotational sliding.
+   mu-rot is friction coefficient.
+   norm-axis is axis of normal (such as fz).
+   slide-axis is axis of sliding direction (such as z)."
+  (let* ((ret (mapcar #'(lambda (x) (make-list 6 :initial-element 0)) '(0 1)))
+         (norm-idx (force-axis->index norm-axis))
+         (slide-idx (+ (axis->index slide-axis) 3))
+         (slide-sgn (axis->sgn slide-axis))
+         )
+    (setf (elt (car ret) norm-idx) mu-rot)
+    (setf (elt (cadr ret) norm-idx) (- mu-rot))
     (cond ((> slide-sgn 0)
            (setf (elt (car ret) slide-idx) 1)
            (setf (elt (cadr ret) slide-idx) -1))

--- a/eus_qp/euslisp/test-contact-wrench-opt.l
+++ b/eus_qp/euslisp/test-contact-wrench-opt.l
@@ -603,6 +603,34 @@
    (list (send *cbox* :worldcoords))
    ))
 
+(defun demo-cbox-wrench-calc-20
+  ()
+  "Demo for cbox wrench calculation by rotational-sliding-contact-constraint. cbox is neutral pos rot."
+  (set-cbox-pose-neutral)
+  (let ((ret (demo-cbox-wrench-calc-comon
+              (list (instance rotational-sliding-contact-constraint :init 0.5 :fz :slide-axis :z))
+              (list (send *cbox* :worldcoords))
+              )))
+    (not ret))
+  )
+
+(defun demo-cbox-wrench-calc-21
+  ()
+  "Demo for cbox wrench calculation by default-contact-constraint. cbox is neutral pos rot. cbox is sliding in the -y direction."
+  (set-cbox-pose-neutral)
+  (demo-cbox-wrench-calc-comon
+   (list (instance default-contact-constraint
+                   :init
+                   :mu-trans 0.5 :mu-rot 0.5
+                   :slide-axis :yaw
+                   :l-min-x -150 :l-max-x 150
+                   :l-min-y -150 :l-max-y 150)
+         (instance 6d-min-max-contact-constraint
+                   :init
+                   (float-vector 100 100 100 100 100 100)))
+   (list (send *cbox* :worldcoords) (send *cbox* :get :face-coords-2))
+   ))
+
 (defun demo-cbox-wrench-calc-all
   (&key (press-enter-p t))
   (let ((ret))


### PR DESCRIPTION
@snozawa 
回転して滑る場合のconstraintを追加しました．
これまで動いていたものはそのまま動きます．
default-constraintで:slide-axisに:yawが設定できるようになりました．