### PR TITLE
[jsk_teleop_joy] update view control in rviz using teleop_joy

### DIFF
--- a/jsk_teleop_joy/src/jsk_teleop_joy/camera_view.py
+++ b/jsk_teleop_joy/src/jsk_teleop_joy/camera_view.py
@@ -19,6 +19,29 @@ class CameraView():
     self.distance = 2.0
     self.focus = numpy.array((0, 0, 0))
     self.z_up = numpy.array((0, 0, 1))
+
+  @staticmethod
+  def createFromCameraPlacement(camera_placement):
+    instance = CameraView()
+    ceye = numpy.array((camera_placement.eye.point.x,
+                        camera_placement.eye.point.y,
+                        camera_placement.eye.point.z))
+    cfocus = numpy.array((camera_placement.focus.point.x,
+                          camera_placement.focus.point.y,
+                          camera_placement.focus.point.z))
+    instance.focus = cfocus
+    viewdir = ceye - cfocus
+    instance.distance = numpy.linalg.norm(viewdir)
+
+    instance.z_up[0] = camera_placement.up.vector.x
+    instance.z_up[1] = camera_placement.up.vector.y
+    instance.z_up[2] = camera_placement.up.vector.z
+
+    instance.pitch = math.asin(viewdir[2]/instance.distance)
+    instance.yaw   = math.atan2(viewdir[1], viewdir[0])
+
+    return instance
+
   def viewPoint(self):
     p = numpy.array((self.distance * math.cos(self.yaw) * math.cos(self.pitch) + self.focus[0],
                      self.distance * math.sin(self.yaw) * math.cos(self.pitch) + self.focus[1],

--- a/jsk_teleop_joy/src/jsk_teleop_joy/joy_status.py
+++ b/jsk_teleop_joy/src/jsk_teleop_joy/joy_status.py
@@ -11,27 +11,30 @@ except:
 
 class JoyStatus():
     def __init__(self):
+        ## buttons
         self.center = False
         self.select = False
         self.start = False
-        self.L3 = False
-        self.R3 = False
-        self.square = False
         self.up = False
         self.down = False
         self.left = False
         self.right = False
-        self.triangle = False
-        self.cross = False
         self.circle = False
+        self.cross = False
+        self.triangle = False
+        self.square = False
         self.L1 = False
         self.R1 = False
         self.L2 = False
         self.R2 = False
+        self.L3 = False
+        self.R3 = False
+        ## analog axis
         self.left_analog_x = 0.0
         self.left_analog_y = 0.0
         self.right_analog_x = 0.0
         self.right_analog_y = 0.0
+        ## analog as buttons
         self.left_analog_up = False
         self.left_analog_down = False
         self.left_analog_left = False
@@ -112,6 +115,17 @@ class JoyStatus():
 
 class XBoxStatus(JoyStatus):
     def __init__(self, msg):
+        '''
+        Xbox game pad
+        Y button => triangle
+        X button => square
+        B button => circle
+        A button => cross
+        RB => R1
+        LB => L1
+        RT => R2
+        LT => L2
+        '''
         JoyStatus.__init__(self)
         if msg.buttons[8] == 1:
             self.center = True

--- a/jsk_teleop_joy/src/jsk_teleop_joy/plugin/joy_pose_6d.py
+++ b/jsk_teleop_joy/src/jsk_teleop_joy/plugin/joy_pose_6d.py
@@ -24,6 +24,24 @@ def signedSquare(val):
  return val * val * sign
 
 class JoyPose6D(RVizViewController):
+  '''
+Usage:
+Left Analog x/y: translate x/y
+Up/Down/Right/Left: rotate pitch/roll
+L1/R2: rotate yaw
+L2/R2: translate z
+square: move faster
+
+Right Analog x/y: yaw/pitch of camera position (see parent class, RVizViewController)
+R3(Right Analog button): suppressing buttons/sticks for controlling pose
+   R3 + L2 + R2: enable follow view mode
+
+Args:
+publish_pose [Boolean, default: True]: Publish or not pose
+frame_id [String, default: /map]: frame_id of publishing pose, this is overwritten by parameter, ~frame_id
+pose [String, default: pose]: topic name for publishing pose
+set_pose [String, default: set_pose]: topic name for setting pose by topic
+  '''
   #def __init__(self, name='JoyPose6D', publish_pose=True):
   def __init__(self, name, args):
     RVizViewController.__init__(self, name, args)
@@ -33,12 +51,13 @@ class JoyPose6D(RVizViewController):
     self.publish_pose = self.getArg('publish_pose', True)
     self.frame_id = self.getArg('frame_id', '/map')
     if self.publish_pose:
-      self.pose_pub = rospy.Publisher(self.getArg('pose', 'pose'), 
+      self.pose_pub = rospy.Publisher(self.getArg('pose', 'pose'),
                                       PoseStamped)
     self.supportFollowView(True)
 
     self.puse_sub = rospy.Subscriber(self.getArg('set_pose', 'set_pose'), PoseStamped, self.setPoseCB)
-    self.frame_id = rospy.get_param('~frame_id', '/map')
+    if rospy.has_param('~frame_id'):
+      self.frame_id = rospy.get_param('~frame_id')
     self.tf_listener = tf.TransformListener()
 
   def setPoseCB(self, pose):
@@ -54,7 +73,8 @@ class JoyPose6D(RVizViewController):
       latest = history.latest()
       if status.R3 and status.L2 and status.R2 and not (latest.R3 and latest.L2 and latest.R2):
         self.followView(not self.followView())
-    RVizViewController.joyCB(self, status, history)
+    if self.control_view:
+      RVizViewController.joyCB(self, status, history)
     new_pose = PoseStamped()
     new_pose.header.frame_id = self.frame_id
     new_pose.header.stamp = rospy.Time(0.0)

--- a/jsk_teleop_joy/src/jsk_teleop_joy/plugin/joy_rviz_view_controller.py
+++ b/jsk_teleop_joy/src/jsk_teleop_joy/plugin/joy_rviz_view_controller.py
@@ -3,10 +3,34 @@
 from jsk_teleop_joy.plugin.rviz_view_controller_singleton import RVizViewControllerManagerSingleton
 from jsk_teleop_joy.joy_plugin import JSKJoyPlugin
 
-  
+import rospy
+
 class RVizViewController(JSKJoyPlugin):
+  '''
+Usage:
+Right Analog x/y: yaw/pitch of camera position
+
+R3(Right Analog button): while holding down L3 button, buttons/sticks listed below work for RVizViewController
+   L3: reset camera pose
+   L1: set focus point to target pose of Pose6D
+   Up/Down/Left/Right : move focus point x/y
+   Left Analog y: move camera for eye direction (near/far)
+   Left Analog x: move focus point for eye direction (near/far)
+   R3 + L2 + R2: enable follow view mode
+
+Args:
+control_view [Boolean, default: True]: Use or not control rviz camera (this is for child class)
+
+Note: code of joyCB is implemented in rviz_view_controller_singleton.py
+      Use TabletViewController(jsk_rviz_plugin) in rviz (selected at 'Views' Panel)
+  '''
   def __init__(self, name, args):
     JSKJoyPlugin.__init__(self, name, args)
+    self.control_view = self.getArg('control_view', True)
+    if not self.control_view:
+      rospy.loginfo("Not using rviz view control")
+      RVizViewControllerManagerSingleton.camera_pub.unregister()
+      RVizViewControllerManagerSingleton.camera_sub.unregister()
   def joyCB(self, status, history):
     RVizViewControllerManagerSingleton.joyCB(status, history, self.pre_pose)
   def supportFollowView(self, val):
@@ -15,4 +39,3 @@ class RVizViewController(JSKJoyPlugin):
     if val != None:
       RVizViewControllerManagerSingleton.follow_view = val
     return RVizViewControllerManagerSingleton.follow_view
-    


### PR DESCRIPTION
joyからrvizのviewを動かす機能について、修正及び機能追加をしました。
修正： pitch周りで1周すると向きが反転していた
　　　view controlが常にpublishされていた
          rvizをマウスで動かした時のviewが反映されずに、joyで動かすとjoyで最後に動かした位置に戻っていた

機能追加： viewのリセットを追加