### PR TITLE
[jsk_footstep_controller/launch] add launch arguments about odometry for hrp2jsk_footcoords

### DIFF
--- a/jsk_footstep_controller/launch/hrp2jsk_footcoords.launch
+++ b/jsk_footstep_controller/launch/hrp2jsk_footcoords.launch
@@ -1,10 +1,14 @@
 <launch>
   <arg name="use_footcoords" default="true"/>
+  <arg name="root_frame_id" default="BODY"/>
+  <arg name="use_wheel_odometry" default="false"/>
   <node pkg="jsk_footstep_controller"
         type="footcoords"
         name="footcoords"
         if="$(arg use_footcoords)"
         >
+    <param name="~root_frame_id" value="$(arg root_frame_id)"/>
+    <remap from="/odom" to="/wheel_odom" if="$(arg use_wheel_odometry)"/>
   </node>
 
   <node pkg="jsk_footstep_controller"


### PR DESCRIPTION
Added arguments related to https://github.com/start-jsk/rtmros_hrp2/pull/465: root_frame_id and use_wheel_odometry (remap flag from /odom to /wheel_odom) for hrp2jsk_footcoords launch.
@orikuma Please check.