### PR TITLE
Replace FootstepState::Ptr to StatePtr in footstep_astar_solver to be used with a GraphT which has different state type

### DIFF
--- a/jsk_footstep_planner/include/jsk_footstep_planner/footstep_astar_solver.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/footstep_astar_solver.h
@@ -94,18 +94,18 @@ namespace jsk_footstep_planner
         SolverNodePtr target_node = popFromOpenList();
         if (graph_->usePointCloudModel() && lazy_projection) {
           unsigned int error_state;
-          FootstepState::Ptr projected_state = graph_->projectFootstep(target_node->getState(),
-                                                                       error_state);
+          StatePtr projected_state = graph_->projectFootstep(target_node->getState(),
+                                                             error_state);
           if (!projected_state) { // failed to project footstep
             if (graph_->localMovement() && error_state == projection_state::close_to_success) {
               // try local movement
-              std::vector<FootstepState::Ptr> locally_moved_states;
+              std::vector<StatePtr> locally_moved_states;
               {
-                std::vector<FootstepState::Ptr> states_candidates
+                std::vector<StatePtr> states_candidates
                   = graph_->localMoveFootstepState(target_node->getState());
                 for (int i = 0; i < states_candidates.size(); i ++) {
-                  FootstepGraph::StatePtr tmp_state = graph_->projectFootstep(states_candidates[i],
-                                                                              error_state);
+                  StatePtr tmp_state = graph_->projectFootstep(states_candidates[i],
+                                                               error_state);
                   if (!!tmp_state) {
                     locally_moved_states.push_back(tmp_state);
                   }
@@ -218,7 +218,7 @@ namespace jsk_footstep_planner
       {
         SolverNodePtr solver_node = copied_open_list.top();
         StatePtr state = solver_node->getState();
-        PointT p = ((FootstepState::Ptr)state)->toPoint<PointT>(); // hacky way
+        PointT p = state->template toPoint<PointT>();
         output_cloud.points.push_back(p);
         copied_open_list.pop();
       }


### PR DESCRIPTION
Problem:
When a FootstepAstarSolver instance is generated with GraphT which has a different state type from FootstepState, a compilation error occurs because there are some hard-coded FootstepState::Ptr in its member functions.

Proposed solution:
I replaced hard-coded FootstepState::Ptr to StatePtr, which is defined in FootstepAstarSolver and equivalent to GraphT::StateT::Ptr, in order to refer the state type used in GraphT. I assume that the behavior of a FootstepAstarSolver with a FootstepGraph is not changed by this PR. 
