### PR TITLE
remove unused build_depends

### DIFF
--- a/jsk_teleop_joy/CMakeLists.txt
+++ b/jsk_teleop_joy/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_teleop_joy)
 
-find_package(catkin REQUIRED COMPONENTS ps3joy tf view_controller_msgs interactive_markers visualization_msgs jsk_footstep_msgs jsk_rviz_plugins) # pr2_controllers_msgs robot_monitor
+find_package(catkin REQUIRED) # pr2_controllers_msgs robot_monitor
 catkin_python_setup()
 
 catkin_package(
-  CATKIN_DEPENDS ps3joy tf view_controller_msgs interactive_markers visualization_msgs jsk_footstep_msgs jsk_rviz_plugins
+  CATKIN_DEPENDS
   
   )
 

--- a/jsk_teleop_joy/package.xml
+++ b/jsk_teleop_joy/package.xml
@@ -9,16 +9,7 @@
   <license>BSD</license>
   <url>http://ros.org/wiki/jsk_teleop_joy</url>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>ps3joy</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>view_controller_msgs</build_depend>
-  <build_depend>interactive_markers</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>jsk_footstep_msgs</build_depend>
-  <build_depend>jsk_interactive_marker</build_depend>
-  <build_depend>diagnostic_msgs</build_depend>
-  <build_depend>diagnostic_updater</build_depend>
-  <build_depend>jsk_rviz_plugins</build_depend>
+
   <run_depend>ps3joy</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>view_controller_msgs</run_depend>
@@ -29,10 +20,10 @@
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>jsk_rviz_plugins</run_depend>
-  <build_depend>joy_mouse</build_depend>
   <run_depend>joy_mouse</run_depend>
   <run_depend>image_view2</run_depend>
   <run_depend>python-pygame</run_depend>
+
   <export>
     <jsk_teleop_joy plugin="${prefix}/plugin.xml"/>
   </export>


### PR DESCRIPTION
to solve aapt-slow issues

c.f.  https://discourse.ros.org/t/preparing-for-indigo-sync-2018-05-14/4767/1, ros-infrastructure/ros_buildfarm#535