### PR TITLE
[eus_qpoases/src/eus_qpoases.cpp] change nWSR for large size QP

### DIFF
--- a/eus_qpoases/src/eus_qpoases.cpp
+++ b/eus_qpoases/src/eus_qpoases.cpp
@@ -51,7 +51,7 @@ double* solve_qpoases_qp_common (double* ret,
   options.printLevel = print_level;
   example.setOptions( options );
   /* Solve first QP/LP. */
-  int nWSR = 1000;
+  int nWSR = 10000;
   returnValue status = example.init( H,g,A,lb,ub,lbA,ubA, nWSR );
   //printf("%d %d %d\n", print_level, PL_NONE, PL_MEDIUM);
   ret_status[0] = getSimpleStatus(status, (print_level != PL_NONE)? BT_TRUE:BT_FALSE);
@@ -133,7 +133,7 @@ double* solve_qpoases_qp_with_hotstart_common (double* ret,
   Options options;
   options.printLevel = print_level;
   example->setOptions( options );
-  int nWSR = 1000;
+  int nWSR = 10000;
   returnValue status;
   if (is_initial) {
     /* Solve first QP/LP. */
@@ -229,7 +229,7 @@ double* solve_qpoases_sqp_with_hotstart_common (double* ret,
   Options options;
   options.printLevel = print_level;
   example->setOptions( options );
-  int nWSR = 1000;
+  int nWSR = 10000;
   returnValue status;
   if (is_initial) {
     /* Solve first QP/LP. */


### PR DESCRIPTION
規模の大きい問題を解くときに，この変更がないと[`:QP-could-not-be-solved-within-given-number-of-iterations`](https://github.com/jsk-ros-pkg/jsk_control/blob/master/eus_qpoases/euslisp/eus-qpoases.l#L285)のエラーが起きます．