### PR TITLE
[eus_qp/optmotiongen/euslisp/inverse-kinematics-wrapper.l] Fix load path

### DIFF
--- a/eus_qp/optmotiongen/euslisp/inverse-kinematics-wrapper.l
+++ b/eus_qp/optmotiongen/euslisp/inverse-kinematics-wrapper.l
@@ -1,5 +1,5 @@
-(load "../trajectory-configuration-task.l")
-(load "../sqp-optimization.l")
+(load "./trajectory-configuration-task.l")
+(load "./sqp-optimization.l")
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Fix load path to load inverse-kinematics-wrapper.l from directories other than the sample or demo directory.