### PR TITLE
Fix and add test of loading euslisp files

### DIFF
--- a/eus_qp/CMakeLists.txt
+++ b/eus_qp/CMakeLists.txt
@@ -25,6 +25,7 @@ add_rostest(test/test_model_predictive_control.test)
 add_rostest(test/test_cfr_cwc_calculation.test)
 add_rostest(optmotiongen/test/test-sample-inverse-kinematics.test)
 add_rostest(optmotiongen/test/test-sample-inverse-kinematics-statics.test)
+add_rostest(optmotiongen/test/test-load-euslisp-files.test)
 
 install(DIRECTORY euslisp test
   USE_SOURCE_PERMISSIONS

--- a/eus_qp/optmotiongen/euslisp/inverse-kinematics-wrapper.l
+++ b/eus_qp/optmotiongen/euslisp/inverse-kinematics-wrapper.l
@@ -1,5 +1,5 @@
-(load "../trajectory-configuration-task.l")
-(load "../sqp-optimization.l")
+(load "./trajectory-configuration-task.l")
+(load "./sqp-optimization.l")
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/eus_qp/optmotiongen/test/test-load-euslisp-files.bash
+++ b/eus_qp/optmotiongen/test/test-load-euslisp-files.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd "$(rospack find eus_qp)"/optmotiongen/euslisp
+EUSLISP_FILES="$(ls -1 *.l)"
+
+for f in $EUSLISP_FILES
+do
+    echo $f
+    roseus "(progn (load \"$f\") (exit))"
+    if [ $? -ne 0 ]; then
+        echo "error when loading $f !!!"
+        exit 1
+    fi
+done
+
+exit 0

--- a/eus_qp/optmotiongen/test/test-load-euslisp-files.l
+++ b/eus_qp/optmotiongen/test/test-load-euslisp-files.l
@@ -1,0 +1,17 @@
+#!/usr/bin/env roseus
+
+(require :unittest "lib/llib/unittest.l")
+
+
+(init-unit-test)
+
+(deftest test-load-euslisp-files
+  (assert (= (unix:system (ros::resolve-ros-path "package://eus_qp/optmotiongen/test/test-load-euslisp-files.bash")) 0))
+  )
+
+
+(eval-when
+ (load eval)
+ (run-all-tests)
+ (exit)
+ )

--- a/eus_qp/optmotiongen/test/test-load-euslisp-files.test
+++ b/eus_qp/optmotiongen/test/test-load-euslisp-files.test
@@ -1,0 +1,4 @@
+<launch>
+  <test test-name="load-optmotiongen-euslisp-files" pkg="eus_qp" type="test-load-euslisp-files.l" time-limit="1000.0">
+  </test>
+</launch>


### PR DESCRIPTION
Add test to find error of https://github.com/jsk-ros-pkg/jsk_control/pull/703 . This pr contains https://github.com/jsk-ros-pkg/jsk_control/pull/703 's fix.

Test working correctly in my forked repository.
1. just add test: https://github.com/jsk-ros-pkg/jsk_control/commit/7832f1b929dbbd4afb1144e6669380920c15365f
https://travis-ci.org/mmurooka/jsk_control/builds/493237231
test failed as expected
```
[eus_qp:make] m;; loading roseus("1.7.4") on euslisp((9.26 ip-172-30-1-221 Mon Dec 17 09:30:19 PST 2018  1.2.1))
[eus_qp:make] mCall Stack (max depth: 20):
[eus_qp:make]   0: at (apply #'ros::load-org-for-ros ros::fullname args)
[eus_qp:make]   1: at (apply #'ros::load-org-for-ros ros::fullname args)
[eus_qp:make]   2: at (let ((ros::fullname fname)) (when (substringp "package://" fname) (setq ros::fullname (ros::resolve-ros-path fname)) (when ros::*compile-message* (let* ((ros::urlname (url-pathname fname)) (package-name (send ros::urlname :host)) (ros::path-name (format nil "~A_~A" package-name (substitute 95 47 (concatenate string (subseq (send ros::urlname :directory-string) 1) (send ros::urlname :name))))) (ros::old-module (find ros::path-name *loaded-modules* :key #'lisp::load-module-file-name :test #'equal))) (unless ros::old-module (let* ((ros::ppath (unix:getenv "CMAKE_PREFIX_PATH")) (dir (format nil "~A/share/roseus/ros/~A" (subseq ros::ppath 0 (position 58 ros::ppath)) package-name))) (unless (probe-file dir) (unix:mkdir dir)) (compiler:compile-file-if-src-newer ros::fullname (format nil "~A/~A" dir ros::path-name)) (return-from load (load (format nil "~A/~A.so" dir ros::path-name) :entry (format nil "___~A" ros::path-name)))))))) (if (null ros::fullname) (error "file ~s not found" fname)) (apply #'ros::load-org-for-ros ros::fullname args))
[eus_qp:make]   3: at (load "../trajectory-configuration-task.l")
[eus_qp:make]   4: at (apply #'ros::load-org-for-ros ros::fullname args)
[eus_qp:make]   5: at (apply #'ros::load-org-for-ros ros::fullname args)
[eus_qp:make]   6: at (let ((ros::fullname fname)) (when (substringp "package://" fname) (setq ros::fullname (ros::resolve-ros-path fname)) (when ros::*compile-message* (let* ((ros::urlname (url-pathname fname)) (package-name (send ros::urlname :host)) (ros::path-name (format nil "~A_~A" package-name (substitute 95 47 (concatenate string (subseq (send ros::urlname :directory-string) 1) (send ros::urlname :name))))) (ros::old-module (find ros::path-name *loaded-modules* :key #'lisp::load-module-file-name :test #'equal))) (unless ros::old-module (let* ((ros::ppath (unix:getenv "CMAKE_PREFIX_PATH")) (dir (format nil "~A/share/roseus/ros/~A" (subseq ros::ppath 0 (position 58 ros::ppath)) package-name))) (unless (probe-file dir) (unix:mkdir dir)) (compiler:compile-file-if-src-newer ros::fullname (format nil "~A/~A" dir ros::path-name)) (return-from load (load (format nil "~A/~A.so" dir ros::path-name) :entry (format nil "___~A" ros::path-name)))))))) (if (null ros::fullname) (error "file ~s not found" fname)) (apply #'ros::load-org-for-ros ros::fullname args))
[eus_qp:make]   7: at (load "./inverse-kinematics-wrapper.l")
[eus_qp:make]   8: at (apply #'ros::load-org-for-ros ros::fullname args)
[eus_qp:make]   9: at (apply #'ros::load-org-for-ros ros::fullname args)
[eus_qp:make]   10: at (let ((ros::fullname fname)) (when (substringp "package://" fname) (setq ros::fullname (ros::resolve-ros-path fname)) (when ros::*compile-message* (let* ((ros::urlname (url-pathname fname)) (package-name (send ros::urlname :host)) (ros::path-name (format nil "~A_~A" package-name (substitute 95 47 (concatenate string (subseq (send ros::urlname :directory-string) 1) (send ros::urlname :name))))) (ros::old-module (find ros::path-name *loaded-modules* :key #'lisp::load-module-file-name :test #'equal))) (unless ros::old-module (let* ((ros::ppath (unix:getenv "CMAKE_PREFIX_PATH")) (dir (format nil "~A/share/roseus/ros/~A" (subseq ros::ppath 0 (position 58 ros::ppath)) package-name))) (unless (probe-file dir) (unix:mkdir dir)) (compiler:compile-file-if-src-newer ros::fullname (format nil "~A/~A" dir ros::path-name)) (return-from load (load (format nil "~A/~A.so" dir ros::path-name) :entry (format nil "___~A" ros::path-name)))))))) (if (null ros::fullname) (error "file ~s not found" fname)) (apply #'ros::load-org-for-ros ros::fullname args))
[eus_qp:make]   11: at (load "inverse-kinematics-statics-wrapper.l")
[eus_qp:make]   12: at (progn (load "inverse-kinematics-statics-wrapper.l") (exit))
[eus_qp:make] /opt/ros/indigo/share/euslisp/jskeus/eus/Linux64/bin/irteusgl: ERROR th=0  0x57c4620 in (apply #'ros::load-org-for-ros ros::fullname args)m[ERROR] test (= (unix:system (ros::resolve-ros-path package://eus_qp/optmotiongen/test/test-load-euslisp-files.bash)) 0) failed ... ( ^[0mmstart testing [test-load-euslisp-files]
[eus_qp:make] l/build/eus_qp/test_results/eus_qp/rosunit-load-optmotiongen-euslisp-files.xml
[eus_qp:make] ).m
[eus_qp:make] mmake[3]: Leaving directory `/home/travis/ros/ws_jsk_control/build/eus_qp'
[eus_qp:make] /usr/bin/make -f CMakeFiles/_run_tests_eus_qp_rostest_optmotiongen_test_test-load-euslisp-files.test.dir/build.make CMakeFiles/_run_tests_eus_qp_rostest_optmotiongen_test_test-load-euslisp-files.test.dir/build
[eus_qp:make] make[3]: Entering directory `/home/travis/ros/ws_jsk_control/build/eus_qp'
[eus_qp:make] catkin_generated/env_cached.sh /usr/bin/python /opt/ros/indigo/share/catkin/cmake/test/run_tests.py /home/travis/ros/ws_jsk_control/build/eus_qp/test_results/eus_qp/rostest-optmotiongen_test_test-load-euslisp-files.xml /opt/ros/indigo/share/rostest/cmake/../../../bin/rostest\ --pkgdir=/home/travis/ros/ws_jsk_control/src/jsk_control/eus_qp\ --package=eus_qp\ --results-filename\ optmotiongen_test_test-load-euslisp-files.xml\ --results-base-dir\ "/home/travis/ros/ws_jsk_control/build/eus_qp/test_results"\ /home/travis/ros/ws_jsk_control/src/jsk_control/eus_qp/optmotiongen/test/test-load-euslisp-files.test\
[eus_qp:make] -- run_tests.py: execute commands
[eus_qp:make]   /opt/ros/indigo/share/rostest/cmake/../../../bin/rostest --pkgdir=/home/travis/ros/ws_jsk_control/src/jsk_control/eus_qp --package=eus_qp --results-filename optmotiongen_test_test-load-euslisp-files.xml --results-base-dir /home/travis/ros/ws_jsk_control/build/eus_qp/test_results /home/travis/ros/ws_jsk_control/src/jsk_control/eus_qp/optmotiongen/test/test-load-euslisp-files.test
[eus_qp:make] ... logging to /home/travis/.ros/log/rostest-e41c61aff280-21609.log
[eus_qp:make] [ROSUNIT] Outputting test results to /home/travis/ros/ws_jsk_control/build/eus_qp/test_results/eus_qp/rostest-optmotiongen_test_test-load-euslisp-files.xml
[eus_qp:make] testload-optmotiongen-euslisp-files ... ERROR!
[eus_qp:make] ERROR: max time [1000.0s] allotted for test [load-optmotiongen-euslisp-files] of type [eus_qp/test-load-euslisp-files.l]

...

[eus_qp:make] [ROSTEST]-----------------------------------------------------------------------
[eus_qp:make]
[eus_qp:make]
[eus_qp:make] SUMMARY
[eus_qp:make] m * RESULT: FAILm
[eus_qp:make]  * TESTS: 0
[eus_qp:make] m * ERRORS: 1m
[eus_qp:make]  * FAILURES: 0
[eus_qp:make]
```
2. fix loading path: https://github.com/jsk-ros-pkg/jsk_control/commit/586f2461f8f79e172d4ddb232962068f5b5db581
https://travis-ci.org/mmurooka/jsk_control/builds/493258278
test passed
