### PR TITLE
[eus_qp/optmotiongen] support min/max angle of root virtual joint

### DIFF
--- a/eus_qp/optmotiongen/euslisp/inverse-kinematics-statics-wrapper.l
+++ b/eus_qp/optmotiongen/euslisp/inverse-kinematics-statics-wrapper.l
@@ -42,6 +42,8 @@
     (contact-move-target)
     (contact-constraint)
     (root-virtual-mode :fix)
+    (root-virtual-joint-min-angle-list)
+    (root-virtual-joint-max-angle-list)
     (joint-angle-margin 0.0)
     (posture-joint-list)
     (posture-joint-angle-list)
@@ -122,6 +124,8 @@ Solve inverse kinematics problem with sqp optimization.
                      :robot self
                      :contact-list (remove nil contact-list)
                      :root-virtual-mode root-virtual-mode
+                     :root-virtual-joint-min-angle-list root-virtual-joint-min-angle-list
+                     :root-virtual-joint-max-angle-list root-virtual-joint-max-angle-list
                      ))
           (variant-joint-list
            (cond (union-link-list
@@ -315,6 +319,8 @@ Solve inverse kinematics problem with sqp optimization.
     (contact-constraint-list)
     (root-virtual-mode :fix)
     (root-virtual-joint-invariant? nil)
+    (root-virtual-joint-min-angle-list)
+    (root-virtual-joint-max-angle-list)
     (joint-angle-margin 0.0)
     (posture-joint-list
      (make-list (length target-coords-list) :initial-element nil))
@@ -485,6 +491,8 @@ Solve inverse kinematics problem with sqp optimization.
                                     :robot robot
                                     :contact-list contact-list
                                     :root-virtual-mode root-virtual-mode
+                                    :root-virtual-joint-min-angle-list root-virtual-joint-min-angle-list
+                                    :root-virtual-joint-max-angle-list root-virtual-joint-max-angle-list
                                     ))
                          )
                     (send robot-env :invariant-joint-list

--- a/eus_qp/optmotiongen/euslisp/inverse-kinematics-wrapper.l
+++ b/eus_qp/optmotiongen/euslisp/inverse-kinematics-wrapper.l
@@ -40,6 +40,8 @@
     (min-loop)
     ;; new arguments
     (root-virtual-mode :fix)
+    (root-virtual-joint-min-angle-list)
+    (root-virtual-joint-max-angle-list)
     (joint-angle-margin 0.0)
     (posture-joint-list)
     (posture-joint-angle-list)
@@ -112,6 +114,8 @@ Solve inverse kinematics problem with sqp optimization.
                      :robot self
                      :contact-list (remove nil contact-list)
                      :root-virtual-mode root-virtual-mode
+                     :root-virtual-joint-min-angle-list root-virtual-joint-min-angle-list
+                     :root-virtual-joint-max-angle-list root-virtual-joint-max-angle-list
                      ))
           (variant-joint-list
            (cond (union-link-list
@@ -250,6 +254,8 @@ Solve inverse kinematics problem with sqp optimization.
     ;; new arguments
     (root-virtual-mode :fix)
     (root-virtual-joint-invariant? nil)
+    (root-virtual-joint-min-angle-list)
+    (root-virtual-joint-max-angle-list)
     (joint-angle-margin 0.0)
     (posture-joint-list
      (make-list (length target-coords-list) :initial-element nil))
@@ -380,6 +386,8 @@ Solve inverse kinematics problem with sqp optimization.
                                     :robot robot
                                     :contact-list (remove nil contact-list)
                                     :root-virtual-mode root-virtual-mode
+                                    :root-virtual-joint-min-angle-list root-virtual-joint-min-angle-list
+                                    :root-virtual-joint-max-angle-list root-virtual-joint-max-angle-list
                                     ))
                          )
                     (send robot-env :invariant-joint-list

--- a/eus_qp/optmotiongen/euslisp/robot-environment.l
+++ b/eus_qp/optmotiongen/euslisp/robot-environment.l
@@ -47,6 +47,8 @@
     (root-virtual-mode :6dof) ;; :6dof, :planar, :fix are supported
     (root-virtual-joint-class-list)
     (root-virtual-joint-axis-list)
+    (root-virtual-joint-min-angle-list)
+    (root-virtual-joint-max-angle-list)
     )
    "
 Initialize instance
@@ -63,6 +65,8 @@ Initialize instance
                       :mode root-virtual-mode
                       :joint-class-list root-virtual-joint-class-list
                       :joint-axis-list root-virtual-joint-axis-list
+                      :joint-min-angle-list root-virtual-joint-min-angle-list
+                      :joint-max-angle-list root-virtual-joint-max-angle-list
                       ))
           ))
    (setq links (flatten (list (send _robot-with-root-virtual :links) (send-all _contact-list :links))))
@@ -78,6 +82,8 @@ Initialize instance
     (mode)
     (joint-class-list)
     (joint-axis-list)
+    (joint-min-angle-list)
+    (joint-max-angle-list)
     )
    (cond ((equal mode :6dof)
           (setq joint-class-list
@@ -92,6 +98,14 @@ Initialize instance
           (setq joint-axis-list
                 (list :x :y :z))
           ))
+   (unless joint-min-angle-list
+     (setq joint-min-angle-list
+           (make-list (length joint-class-list) :initial-element -1e10))
+     )
+   (unless joint-max-angle-list
+     (setq joint-max-angle-list
+           (make-list (length joint-class-list) :initial-element 1e10))
+     )
    (let ((cl-with-rv (instance cascaded-link :init))
          rv-ll
          )
@@ -122,19 +136,23 @@ Initialize instance
                               joint-axis
                               parent-link
                               child-link
+                              min-angle
+                              max-angle
                               )
                        (instance joint-class :init
                                  :name
                                  (read-from-string
                                   (format nil ":~a-root-virtual-~a-~a" (send target :name) (send joint-class :name) (symbol-name joint-axis)))
                                  :parent-link parent-link :child-link child-link
-                                 :axis joint-axis :min -1e10 :max 1e10
+                                 :axis joint-axis :min min-angle :max max-angle
                                  :max-joint-torque 0.0
                                  ))
                    joint-class-list
                    joint-axis-list
                    (butlast (append rv-ll (list target)))
                    (cdr (append rv-ll (list target)))
+                   joint-min-angle-list
+                   joint-max-angle-list
                    ))
      ;; 3. init-ending
      (mapcar #'(lambda (jnt

--- a/eus_qp/optmotiongen/euslisp/sample/sample-inverse-kinematics.l
+++ b/eus_qp/optmotiongen/euslisp/sample/sample-inverse-kinematics.l
@@ -592,6 +592,9 @@
     (&key
      (target-coords
       (make-coords :pos (float-vector 400 -200 300) :rpy (list (deg2rad 60) 0 0)))
+     (rotation-axis-list (list t t t))
+     (root-virtual-joint-min-angle-list)
+     (root-virtual-joint-max-angle-list)
      (pre-process-func)
      (post-process-func)
      &allow-other-keys
@@ -608,9 +611,12 @@
         :inverse-kinematics-trajectory-optmotiongen
         (send-all *arrow-list* :copy-worldcoords)
         :move-target-list (send *robot* :end-coords)
+        :rotation-axis-list rotation-axis-list
         :debug-view (list :additional-draw-objects *arrow-list*)
         :root-virtual-mode :planar
         :root-virtual-joint-invariant? t
+        :root-virtual-joint-min-angle-list root-virtual-joint-min-angle-list
+        :root-virtual-joint-max-angle-list root-virtual-joint-max-angle-list
         :pre-process-func pre-process-func
         :post-process-func post-process-func
         )

--- a/eus_qp/optmotiongen/test/test-sample-inverse-kinematics.l
+++ b/eus_qp/optmotiongen/test/test-sample-inverse-kinematics.l
@@ -39,7 +39,13 @@
   (assert (null-output (sample-arm-reach-trajectory-ik-raw)))
   (assert (null-output (consp (sample-arm-reach-trajectory-ik))))
   (assert (null-output (consp (sample-arm-reach-trajectory-ik-with-root-virtual-joint))))
-  (assert (null-output (null (sample-arm-reach-trajectory-ik-with-root-virtual-joint :target-coords (make-coords :pos (float-vector 10000 0 0)))))) ;; intentional failure
+  (assert (null-output (null (sample-arm-reach-trajectory-ik-with-root-virtual-joint
+                              :target-coords (make-coords :pos (float-vector 10000 0 0)))))) ;; intentional failure
+  (assert (null-output (null (sample-arm-reach-trajectory-ik-with-root-virtual-joint
+                              :root-virtual-joint-min-angle-list (list 0 0 0) :root-virtual-joint-max-angle-list (list 0 0 0))))) ;; intentional failure
+  (assert (null-output (consp (sample-arm-reach-trajectory-ik-with-root-virtual-joint
+                               :rotation-axis-list (list nil nil nil)
+                               :root-virtual-joint-min-angle-list (list -1e10 0 0) :root-virtual-joint-max-angle-list (list 1e10 0 0)))))
   (assert (null-output (consp (sample-arm-reach-trajectory-ik-with-root-virtual-joint-obstacle))))
   )
 


### PR DESCRIPTION
Add key arguments, `:root-virtual-joint-min-angle-list` and `:root-virtual-joint-max-angle-list` from inverse kinematics wrapper methods. Add tests of these arguments in travis test.
FYI @iory