### PR TITLE
[optmotiongen] :play-motionで力を描画させる

### DIFF
--- a/eus_qp/optmotiongen/euslisp/sample/sample-sqp-optimization-trajectory.l
+++ b/eus_qp/optmotiongen/euslisp/sample/sample-sqp-optimization-trajectory.l
@@ -8,71 +8,76 @@
      (mu-rot 0.01)
      (max-fz 500)
      (support-polygon-margin 20)
+     (coords-name-list (list :rleg-contact-coords :lleg-contact-coords :rarm-contact-coords :larm-contact-coords))
      )
-  (send (send *robot-env* :robot :get :rleg-contact-coords)
-        :put :contact-constraint
-        (instance* default-contact-constraint
-                   :init
-                   :mu-trans mu-trans
-                   :mu-rot mu-rot
-                   :max-fz max-fz
-                   (let* ((poly
-                           (send *robot-env* :robot :get :rleg_link5-support-polygon))
-                          (vs
-                           (mapcar #'(lambda (v)
-                                       (send (send (send *robot-env* :robot :get :rleg-contact-coords) :worldcoords)
-                                             :inverse-transform-vector v))
-                                   (send poly :vertices)
-                                   ))
-                          )
-                     (list :l-min-x (+ (elt (find-extream vs #'(lambda (v) (elt v 0)) #'<) 0) support-polygon-margin)
-                           :l-max-x (- (elt (find-extream vs #'(lambda (v) (elt v 0)) #'>) 0) support-polygon-margin)
-                           :l-min-y (+ (elt (find-extream vs #'(lambda (v) (elt v 1)) #'<) 1) support-polygon-margin)
-                           :l-max-y (- (elt (find-extream vs #'(lambda (v) (elt v 1)) #'>) 1) support-polygon-margin)
-                           ))
-                   ))
-  (send (send *robot-env* :robot :get :lleg-contact-coords)
-        :put :contact-constraint
-        (instance* default-contact-constraint
-                   :init
-                   :mu-trans mu-trans
-                   :mu-rot mu-rot
-                   :max-fz max-fz
-                   (let* ((poly
-                           (send *robot-env* :robot :get :lleg_link5-support-polygon))
-                          (vs
-                           (mapcar #'(lambda (v)
-                                       (send (send (send *robot-env* :robot :get :lleg-contact-coords) :worldcoords)
-                                             :inverse-transform-vector v))
-                                   (send poly :vertices)
-                                   ))
-                          )
-                     (list :l-min-x (+ (elt (find-extream vs #'(lambda (v) (elt v 0)) #'<) 0) support-polygon-margin)
-                           :l-max-x (- (elt (find-extream vs #'(lambda (v) (elt v 0)) #'>) 0) support-polygon-margin)
-                           :l-min-y (+ (elt (find-extream vs #'(lambda (v) (elt v 1)) #'<) 1) support-polygon-margin)
-                           :l-max-y (- (elt (find-extream vs #'(lambda (v) (elt v 1)) #'>) 1) support-polygon-margin)
-                           ))
-                   ))
-  (send (send *robot-env* :robot :get :rarm-contact-coords)
-        :put :contact-constraint
-        (instance default-contact-constraint
-                  :init
-                  :mu-trans mu-trans
-                  :mu-rot mu-rot
-                  :max-fz max-fz
-                  ;; :contact-face (send *robot-env* :robot :get :rarm_link6-support-polygon)
-                  :l-min-x -1 :l-max-x -1 :l-min-y 1 :l-max-y 1
-                  ))
-  (send (send *robot-env* :robot :get :larm-contact-coords)
-        :put :contact-constraint
-        (instance default-contact-constraint
-                  :init
-                  :mu-trans mu-trans
-                  :mu-rot mu-rot
-                  :max-fz max-fz
-                  ;; :contact-face (send *robot-env* :robot :get :larm_link6-support-polygon)
-                  :l-min-x -1 :l-max-x -1 :l-min-y 1 :l-max-y 1
-                  ))
+  (if (member :rleg-contact-coords coords-name-list)
+      (send (send *robot-env* :robot :get :rleg-contact-coords)
+            :put :contact-constraint
+            (instance* default-contact-constraint
+                       :init
+                       :mu-trans mu-trans
+                       :mu-rot mu-rot
+                       :max-fz max-fz
+                       (let* ((poly
+                               (send *robot-env* :robot :get :rleg_link5-support-polygon))
+                              (vs
+                               (mapcar #'(lambda (v)
+                                           (send (send (send *robot-env* :robot :get :rleg-contact-coords) :worldcoords)
+                                                 :inverse-transform-vector v))
+                                       (send poly :vertices)
+                                       ))
+                              )
+                         (list :l-min-x (+ (elt (find-extream vs #'(lambda (v) (elt v 0)) #'<) 0) support-polygon-margin)
+                               :l-max-x (- (elt (find-extream vs #'(lambda (v) (elt v 0)) #'>) 0) support-polygon-margin)
+                               :l-min-y (+ (elt (find-extream vs #'(lambda (v) (elt v 1)) #'<) 1) support-polygon-margin)
+                               :l-max-y (- (elt (find-extream vs #'(lambda (v) (elt v 1)) #'>) 1) support-polygon-margin)
+                               ))
+                       )))
+  (if (member :lleg-contact-coords coords-name-list)
+      (send (send *robot-env* :robot :get :lleg-contact-coords)
+            :put :contact-constraint
+            (instance* default-contact-constraint
+                       :init
+                       :mu-trans mu-trans
+                       :mu-rot mu-rot
+                       :max-fz max-fz
+                       (let* ((poly
+                               (send *robot-env* :robot :get :lleg_link5-support-polygon))
+                              (vs
+                               (mapcar #'(lambda (v)
+                                           (send (send (send *robot-env* :robot :get :lleg-contact-coords) :worldcoords)
+                                                 :inverse-transform-vector v))
+                                       (send poly :vertices)
+                                       ))
+                              )
+                         (list :l-min-x (+ (elt (find-extream vs #'(lambda (v) (elt v 0)) #'<) 0) support-polygon-margin)
+                               :l-max-x (- (elt (find-extream vs #'(lambda (v) (elt v 0)) #'>) 0) support-polygon-margin)
+                               :l-min-y (+ (elt (find-extream vs #'(lambda (v) (elt v 1)) #'<) 1) support-polygon-margin)
+                               :l-max-y (- (elt (find-extream vs #'(lambda (v) (elt v 1)) #'>) 1) support-polygon-margin)
+                               ))
+                       )))
+  (if (member :rarm-contact-coords coords-name-list)
+      (send (send *robot-env* :robot :get :rarm-contact-coords)
+            :put :contact-constraint
+            (instance default-contact-constraint
+                      :init
+                      :mu-trans mu-trans
+                      :mu-rot mu-rot
+                      :max-fz max-fz
+                      ;; :contact-face (send *robot-env* :robot :get :rarm_link6-support-polygon)
+                      :l-min-x -1 :l-max-x -1 :l-min-y 1 :l-max-y 1
+                      )))
+  (if (member :larm-contact-coords coords-name-list)
+      (send (send *robot-env* :robot :get :larm-contact-coords)
+            :put :contact-constraint
+            (instance default-contact-constraint
+                      :init
+                      :mu-trans mu-trans
+                      :mu-rot mu-rot
+                      :max-fz max-fz
+                      ;; :contact-face (send *robot-env* :robot :get :larm_link6-support-polygon)
+                      :l-min-x -1 :l-max-x -1 :l-min-y 1 :l-max-y 1
+                      )))
   )
 
 (defun sample-sqp-optimization-trajectory
@@ -168,6 +173,7 @@
    *instant-config-task-list*
    )
 
+  (setup-contact-constraint-for-sample-sqp-optimization :max-fz 0 :coords-name-list (list :lleg-contact-coords))
   (push (copy-object *robot-env*) *robot-env-list*)
   (push
    (instance instant-configuration-task :init
@@ -188,11 +194,13 @@
                    )
              :contact-target-coords-list
              (list (send (car *robot-env-list*) :contact "rleg" :contact-coords)
+                   (make-coords :pos (float-vector 300 200 0))
                    (send (car *robot-env-list*) :contact "rarm" :contact-coords)
                    (send (car *robot-env-list*) :contact "larm" :contact-coords)
                    )
              :contact-attention-coords-list
              (list (send (car *robot-env-list*) :robot :get :rleg-contact-coords)
+                   (send (car *robot-env-list*) :robot :get :lleg-contact-coords)
                    (send (car *robot-env-list*) :robot :get :rarm-contact-coords)
                    (send (car *robot-env-list*) :robot :get :larm-contact-coords)
                    )
@@ -200,6 +208,7 @@
    *instant-config-task-list*
    )
 
+  (setup-contact-constraint-for-sample-sqp-optimization)
   (push (copy-object *robot-env*) *robot-env-list*)
   (push
    (instance instant-configuration-task :init
@@ -298,6 +307,7 @@
    *instant-config-task-list*
    )
 
+  (setup-contact-constraint-for-sample-sqp-optimization :max-fz 0 :coords-name-list (list :lleg-contact-coords))
   (push (copy-object *robot-env*) *robot-env-list*)
   (push
    (instance instant-configuration-task :init
@@ -318,11 +328,13 @@
                    )
              :contact-target-coords-list
              (list (send (car *robot-env-list*) :contact "rleg" :contact-coords)
+                   (send (car *robot-env-list*) :contact "lleg" :contact-coords)
                    (send (car *robot-env-list*) :contact "rarm" :contact-coords)
                    (send (car *robot-env-list*) :contact "larm" :contact-coords)
                    )
              :contact-attention-coords-list
              (list (send (car *robot-env-list*) :robot :get :rleg-contact-coords)
+                   (send (car *robot-env-list*) :robot :get :lleg-contact-coords)
                    (send (car *robot-env-list*) :robot :get :rarm-contact-coords)
                    (send (car *robot-env-list*) :robot :get :larm-contact-coords)
                    )
@@ -330,6 +342,7 @@
    *instant-config-task-list*
    )
 
+  (setup-contact-constraint-for-sample-sqp-optimization)
   (push (copy-object *robot-env*) *robot-env-list*)
   (push
    (instance instant-configuration-task :init
@@ -364,6 +377,7 @@
    *instant-config-task-list*
    )
 
+  (setup-contact-constraint-for-sample-sqp-optimization :max-fz 0 :coords-name-list (list :rleg-contact-coords))
   (push (copy-object *robot-env*) *robot-env-list*)
   (push
    (instance instant-configuration-task :init
@@ -383,12 +397,14 @@
                    (send (car *robot-env-list*) :robot :get :larm-contact-coords)
                    )
              :contact-target-coords-list
-             (list (send (car *robot-env-list*) :contact "lleg" :contact-coords)
+             (list (send (car *robot-env-list*) :contact "rleg" :contact-coords)
+                   (send (car *robot-env-list*) :contact "lleg" :contact-coords)
                    (send (car *robot-env-list*) :contact "rarm" :contact-coords)
                    (send (car *robot-env-list*) :contact "larm" :contact-coords)
                    )
              :contact-attention-coords-list
-             (list (send (car *robot-env-list*) :robot :get :lleg-contact-coords)
+             (list (send (car *robot-env-list*) :robot :get :rleg-contact-coords)
+                   (send (car *robot-env-list*) :robot :get :lleg-contact-coords)
                    (send (car *robot-env-list*) :robot :get :rarm-contact-coords)
                    (send (car *robot-env-list*) :robot :get :larm-contact-coords)
                    )
@@ -396,6 +412,7 @@
    *instant-config-task-list*
    )
 
+  (setup-contact-constraint-for-sample-sqp-optimization)
   (push (copy-object *robot-env*) *robot-env-list*)
   (push
    (instance instant-configuration-task :init

--- a/eus_qp/optmotiongen/euslisp/trajectory-configuration-task.l
+++ b/eus_qp/optmotiongen/euslisp/trajectory-configuration-task.l
@@ -1,4 +1,4 @@
-(load "./instant-configuration-task.l")
+(load "./instant-manipulation-configuration-task.l")
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -787,6 +787,7 @@ Print status.
     (robot-env)
     (loop? t)
     (visualize-callback-func)
+    (visualize-force? nil)
     )
    "
 Play motion.
@@ -801,17 +802,66 @@ Play motion.
           )
      (do-until-key
       (dotimes (i (1- (length _instant-config-task-list)))
-        (let* ((av-current
-                (send (send (elt (if reverse? (reverse _instant-config-task-list) _instant-config-task-list) i)
-                            :robot-env) :angle-vector))
-               (av-next
-                (send (send (elt (if reverse? (reverse _instant-config-task-list) _instant-config-task-list) (1+ i))
-                            :robot-env) :angle-vector))
+        (let* ((instant-config-task-current
+                (elt (if reverse? (reverse _instant-config-task-list) _instant-config-task-list) i))
+               (instant-config-task-next
+                (elt (if reverse? (reverse _instant-config-task-list) _instant-config-task-list) (1+ i)))
+               (tmp-short-len)
                )
           (dotimes (j 10)
-            (send robot-env :angle-vector (midpoint (/ (float (1+ j)) 10) av-current av-next))
-            (x::window-main-one)
+            (send robot-env :angle-vector
+                  (midpoint (/ (float (1+ j)) 10)
+                            (send (send instant-config-task-current :robot-env) :angle-vector)
+                            (send (send instant-config-task-next :robot-env) :angle-vector)))
             (send *irtviewer* :draw-objects :flush nil)
+            (if visualize-force?
+                (progn
+                  ;; draw force and moment of the robot
+                  (setq tmp-short-len
+                        (min (length (send instant-config-task-current :force-list))
+                             (length (send instant-config-task-next :force-list))))
+                  (draw-force-value
+                   :force-list
+                   (midvec-list
+                    (/ (float (1+ j)) 10)
+                    (subseq (send instant-config-task-current :force-list) 0 tmp-short-len)
+                    (subseq (send instant-config-task-next :force-list) 0 tmp-short-len))
+                   :moment-list
+                   (midvec-list
+                    (/ (float (1+ j)) 10)
+                    (subseq (send instant-config-task-current :moment-list) 0 tmp-short-len)
+                    (subseq (send instant-config-task-next :moment-list) 0 tmp-short-len))
+                   :coords-list
+                   (midcoords-list
+                    (/ (float (1+ j)) 10)
+                    (subseq (send instant-config-task-current :contact-target-coords-list) 0 tmp-short-len)
+                    (subseq (send instant-config-task-next :contact-target-coords-list) 0 tmp-short-len))
+                   :force-color #f(0.8 0.2 0.2)
+                   :draw-cop? nil
+                   )
+                  ;; draw force and moment of the object
+                  (if (and (derivedp instant-config-task-current instant-manipulation-configuration-task)
+                           (derivedp instant-config-task-next instant-manipulation-configuration-task))
+                      (draw-force-value
+                       :force-list
+                       (midvec-list
+                        (/ (float (1+ j)) 10)
+                        (subseq (send instant-config-task-current :force-obj-list) 0 tmp-short-len)
+                        (subseq (send instant-config-task-next :force-obj-list) 0 tmp-short-len))
+                       :moment-list
+                       (midvec-list
+                        (/ (float (1+ j)) 10)
+                        (subseq (send instant-config-task-current :moment-obj-list) 0 tmp-short-len)
+                        (subseq (send instant-config-task-next :moment-obj-list) 0 tmp-short-len))
+                       :coords-list
+                       (midcoords-list
+                        (/ (float (1+ j)) 10)
+                        (subseq (send instant-config-task-current :contact-target-coords-obj-list) 0 tmp-short-len)
+                        (subseq (send instant-config-task-next :contact-target-coords-obj-list) 0 tmp-short-len))
+                       :force-color #f(0.8 0.2 0.2)
+                       :draw-cop? nil
+                       ))))
+            (x::window-main-one)
             (send *irtviewer* :viewer :flush)
             (unix::usleep (* 40 1000))
             (when visualize-callback-func

--- a/eus_qp/optmotiongen/euslisp/trajectory-configuration-task.l
+++ b/eus_qp/optmotiongen/euslisp/trajectory-configuration-task.l
@@ -842,25 +842,29 @@ Play motion.
                   ;; draw force and moment of the object
                   (if (and (derivedp instant-config-task-current instant-manipulation-configuration-task)
                            (derivedp instant-config-task-next instant-manipulation-configuration-task))
-                      (draw-force-value
-                       :force-list
-                       (midvec-list
-                        (/ (float (1+ j)) 10)
-                        (subseq (send instant-config-task-current :force-obj-list) 0 tmp-short-len)
-                        (subseq (send instant-config-task-next :force-obj-list) 0 tmp-short-len))
-                       :moment-list
-                       (midvec-list
-                        (/ (float (1+ j)) 10)
-                        (subseq (send instant-config-task-current :moment-obj-list) 0 tmp-short-len)
-                        (subseq (send instant-config-task-next :moment-obj-list) 0 tmp-short-len))
-                       :coords-list
-                       (midcoords-list
-                        (/ (float (1+ j)) 10)
-                        (subseq (send instant-config-task-current :contact-target-coords-obj-list) 0 tmp-short-len)
-                        (subseq (send instant-config-task-next :contact-target-coords-obj-list) 0 tmp-short-len))
-                       :force-color #f(0.8 0.2 0.2)
-                       :draw-cop? nil
-                       ))))
+                      (progn
+                        (setq tmp-short-len
+                              (min (length (send instant-config-task-current :force-obj-list))
+                                   (length (send instant-config-task-next :force-obj-list))))
+                        (draw-force-value
+                         :force-list
+                         (midvec-list
+                          (/ (float (1+ j)) 10)
+                          (subseq (send instant-config-task-current :force-obj-list) 0 tmp-short-len)
+                          (subseq (send instant-config-task-next :force-obj-list) 0 tmp-short-len))
+                         :moment-list
+                         (midvec-list
+                          (/ (float (1+ j)) 10)
+                          (subseq (send instant-config-task-current :moment-obj-list) 0 tmp-short-len)
+                          (subseq (send instant-config-task-next :moment-obj-list) 0 tmp-short-len))
+                         :coords-list
+                         (midcoords-list
+                          (/ (float (1+ j)) 10)
+                          (subseq (send instant-config-task-current :contact-target-coords-obj-list) 0 tmp-short-len)
+                          (subseq (send instant-config-task-next :contact-target-coords-obj-list) 0 tmp-short-len))
+                         :force-color #f(0.8 0.2 0.2)
+                         :draw-cop? nil
+                         )))))
             (x::window-main-one)
             (send *irtviewer* :viewer :flush)
             (unix::usleep (* 40 1000))

--- a/eus_qp/optmotiongen/euslisp/trajectory-configuration-task.l
+++ b/eus_qp/optmotiongen/euslisp/trajectory-configuration-task.l
@@ -1,4 +1,4 @@
-(load "./instant-manipulation-configuration-task.l")
+(load "./instant-configuration-task.l")
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -788,6 +788,7 @@ Print status.
     (loop? t)
     (visualize-callback-func)
     (visualize-force? nil)
+    (force-color #f(0.8 0.2 0.2))
     )
    "
 Play motion.
@@ -806,7 +807,11 @@ Play motion.
                 (elt (if reverse? (reverse _instant-config-task-list) _instant-config-task-list) i))
                (instant-config-task-next
                 (elt (if reverse? (reverse _instant-config-task-list) _instant-config-task-list) (1+ i)))
-               (tmp-short-len)
+               (name-set)
+               (current-name-list)
+               (next-name-list)
+               (current-coords-idx)
+               (next-coords-idx)
                )
           (dotimes (j 10)
             (send robot-env :angle-vector
@@ -817,54 +822,42 @@ Play motion.
             (if visualize-force?
                 (progn
                   ;; draw force and moment of the robot
-                  (setq tmp-short-len
-                        (min (length (send instant-config-task-current :force-list))
-                             (length (send instant-config-task-next :force-list))))
+                  (setq name-set
+                        (intersection
+                         (setq current-name-list (send-all (send instant-config-task-current :contact-attention-coords-list) :name))
+                         (setq next-name-list (send-all (send instant-config-task-next :contact-attention-coords-list) :name))))
+                  (dolist (name name-set)
+                    (setq current-coords-idx
+                          (concatenate cons current-coords-idx
+                                       (list (position-if #'(lambda (nm) (string= nm name)) current-name-list))))
+                    (setq next-coords-idx
+                          (concatenate cons next-coords-idx
+                                       (list (position-if #'(lambda (nm) (string= nm name)) next-name-list)))))
                   (draw-force-value
                    :force-list
                    (midvec-list
                     (/ (float (1+ j)) 10)
-                    (subseq (send instant-config-task-current :force-list) 0 tmp-short-len)
-                    (subseq (send instant-config-task-next :force-list) 0 tmp-short-len))
+                    (mapcar #'(lambda (idx) (elt (send instant-config-task-current :force-list) idx))
+                            current-coords-idx)
+                    (mapcar #'(lambda (idx) (elt (send instant-config-task-next :force-list) idx))
+                            next-coords-idx))
                    :moment-list
                    (midvec-list
                     (/ (float (1+ j)) 10)
-                    (subseq (send instant-config-task-current :moment-list) 0 tmp-short-len)
-                    (subseq (send instant-config-task-next :moment-list) 0 tmp-short-len))
+                    (mapcar #'(lambda (idx) (elt (send instant-config-task-current :moment-list) idx))
+                            current-coords-idx)
+                    (mapcar #'(lambda (idx) (elt (send instant-config-task-next :moment-list) idx))
+                            next-coords-idx))
                    :coords-list
                    (midcoords-list
                     (/ (float (1+ j)) 10)
-                    (subseq (send instant-config-task-current :contact-target-coords-list) 0 tmp-short-len)
-                    (subseq (send instant-config-task-next :contact-target-coords-list) 0 tmp-short-len))
-                   :force-color #f(0.8 0.2 0.2)
+                    (mapcar #'(lambda (idx) (elt (send instant-config-task-current :contact-target-coords-list) idx))
+                            current-coords-idx)
+                    (mapcar #'(lambda (idx) (elt (send instant-config-task-next :contact-target-coords-list) idx))
+                            next-coords-idx))
+                   :force-color force-color
                    :draw-cop? nil
-                   )
-                  ;; draw force and moment of the object
-                  (if (and (derivedp instant-config-task-current instant-manipulation-configuration-task)
-                           (derivedp instant-config-task-next instant-manipulation-configuration-task))
-                      (progn
-                        (setq tmp-short-len
-                              (min (length (send instant-config-task-current :force-obj-list))
-                                   (length (send instant-config-task-next :force-obj-list))))
-                        (draw-force-value
-                         :force-list
-                         (midvec-list
-                          (/ (float (1+ j)) 10)
-                          (subseq (send instant-config-task-current :force-obj-list) 0 tmp-short-len)
-                          (subseq (send instant-config-task-next :force-obj-list) 0 tmp-short-len))
-                         :moment-list
-                         (midvec-list
-                          (/ (float (1+ j)) 10)
-                          (subseq (send instant-config-task-current :moment-obj-list) 0 tmp-short-len)
-                          (subseq (send instant-config-task-next :moment-obj-list) 0 tmp-short-len))
-                         :coords-list
-                         (midcoords-list
-                          (/ (float (1+ j)) 10)
-                          (subseq (send instant-config-task-current :contact-target-coords-obj-list) 0 tmp-short-len)
-                          (subseq (send instant-config-task-next :contact-target-coords-obj-list) 0 tmp-short-len))
-                         :force-color #f(0.8 0.2 0.2)
-                         :draw-cop? nil
-                         )))))
+                   )))
             (x::window-main-one)
             (send *irtviewer* :viewer :flush)
             (unix::usleep (* 40 1000))

--- a/eus_qp/optmotiongen/euslisp/util.l
+++ b/eus_qp/optmotiongen/euslisp/util.l
@@ -133,6 +133,21 @@ Override to support zero row matrix.
        (setf ,lst (list ,el))
      (nconc ,lst (list ,el))))
 
+(defun midvec-list
+  (ratio vec-1-list vec-2-list)
+   (mapcar #'(lambda (vec-1 vec-2)
+               (v+ (scale (- 1 ratio) vec-1)
+                   (scale ratio vec-2)))
+           vec-1-list
+           vec-2-list))
+
+(defun midcoords-list
+  (ratio cds-1-list cds-2-list)
+  (mapcar #'(lambda (cds-1 cds-2)
+              (midcoords
+               ratio cds-1 cds-2))
+          cds-1-list
+          cds-2-list))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; geometry


### PR DESCRIPTION
:play-motionで力を描画出来るようにするための変更です。

@mmurooka 
現状のプログラムですと、隣あったinstant-config-task同士で、
contact-target-coords-listに入っているcoordsが前から順番に同じものでなければ
うまくいかないプログラムになってしまっているのですが、
これをうまく回避する方法というのはあったりするのでしょうか？
contact-target-coordsに名前は入っていないように思います。

現状では、例えば以下のような書き方をされているプログラムですとうまく描画されないです。
[(make-coords :pos (float-vector 300 200 0))](https://github.com/jsk-ros-pkg/jsk_control/blob/master/eus_qp/optmotiongen/euslisp/demo/demo-rhp4b-step-block-terrain.l#L241)
と
[(send (car *robot-env-list*) :contact "rarm" :contact-coords)](https://github.com/jsk-ros-pkg/jsk_control/blob/master/eus_qp/optmotiongen/euslisp/demo/demo-rhp4b-step-block-terrain.l#L279)
が対応している。