### PR TITLE
[stabilizer_watcher.py]fix for kinetic

### DIFF
--- a/jsk_footstep_controller/scripts/stabilizer_watcher.py
+++ b/jsk_footstep_controller/scripts/stabilizer_watcher.py
@@ -48,6 +48,7 @@ def trig():
     sound = SoundRequest()
     sound.sound = SoundRequest.SAY
     sound.command = SoundRequest.PLAY_ONCE
+    sound.volume = 1.0
     sound.arg = "Robot stands on the ground."
     g_robotsound_pub.publish(sound)
     


### PR DESCRIPTION
robotsoundが

indigoからkineticに変わるときにSoundRequest型が変わり、
新たにvolumeというパラメータができました。

デフォルト値では音量0となってロボットが喋らないため、
volumeに値をセットしました。
