### PR TITLE
[eus_qpoases.cpp] options.setToReliable()

### DIFF
--- a/eus_qpoases/src/eus_qpoases.cpp
+++ b/eus_qpoases/src/eus_qpoases.cpp
@@ -48,6 +48,7 @@ double* solve_qpoases_qp_common (double* ret,
 
   QProblem example( state_len,inequality_len, (solve_lp ? HST_ZERO : HST_UNKNOWN));
   Options options;
+  options.setToReliable();
   options.printLevel = print_level;
   example.setOptions( options );
   /* Solve first QP/LP. */
@@ -131,6 +132,7 @@ double* solve_qpoases_qp_with_hotstart_common (double* ret,
   }
 
   Options options;
+  options.setToReliable();
   options.printLevel = print_level;
   example->setOptions( options );
   int nWSR = 10000;
@@ -227,6 +229,7 @@ double* solve_qpoases_sqp_with_hotstart_common (double* ret,
   }
 
   Options options;
+  options.setToReliable();
   options.printLevel = print_level;
   example->setOptions( options );
   int nWSR = 10000;


### PR DESCRIPTION
eus_qpoasesを使用しているときに、
```
:QP-could-not-be-solved-due-to-an-internal-error
```
によってQPが失敗することがしばしばあります．
QPを解くのに多少時間がかかるようになりますが、安定して解けるようなオプションを使用するように変更しました。

https://projects.coin-or.org/qpOASES/export/1/trunk/doc/manual.pdf より
```
setToReliable( );chooses values that ensure maximum reliabilty of the QP solu-tion (usually at the expense of a slower execution
```