### PR TITLE
[jsk_ik_server] use torso for pr2 reachability map

### DIFF
--- a/jsk_ik_server/scripts/ik-grid/pr2.l
+++ b/jsk_ik_server/scripts/ik-grid/pr2.l
@@ -8,25 +8,25 @@
 (setq *robot* (make-robot-model-from-name "pr2"))
 (setq *xrange* '(0.0 . 1000.0))
 (setq *yrange* '(-1000.0 . 2200.0))
-(setq *zrange* '(0.0 . 1500.0))
+(setq *zrange* '(0.0 . 2000.0))
 (setq *output-directory* (ros::resolve-ros-path "package://jsk_ik_server/data/"))
 
 (generate-ik-grid-for-robot *robot* "pr2-zup"
                             *xrange* *yrange* *zrange*
                             100
-                            '(:rotation-axis :z)
+                            '(:rotation-axis :z :use-torso t)
                             (unit-matrix)
                             *output-directory*)
 (generate-ik-grid-for-robot *robot* "pr2-yup"
                             *xrange* *yrange* *zrange*
                             100
-                            '(:rotation-axis :z)
+                            '(:rotation-axis :z :use-torso t)
                             (send (make-coords :rpy (list 0 0 pi/2)) :worldrot)
                             *output-directory*)
 (generate-ik-grid-for-robot *robot* "pr2-xup"
                             *xrange* *yrange* *zrange*
                             100
-                            '(:rotation-axis :z)
+                            '(:rotation-axis :z :use-torso t)
                             (send (make-coords :rpy (list 0 -pi/2 0)) :worldrot)
                             *output-directory*)
 


### PR DESCRIPTION
`use-torso t` for pr2 reachability calculation