### PR TITLE
[jsk_teleop_joy] python3-pygame is required on noetic

### DIFF
--- a/jsk_teleop_joy/package.xml
+++ b/jsk_teleop_joy/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>jsk_teleop_joy</name>
   <description>
      jsk_teleop_joy
@@ -10,19 +10,20 @@
   <url>http://ros.org/wiki/jsk_teleop_joy</url>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>ps3joy</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>view_controller_msgs</run_depend>
-  <run_depend>interactive_markers</run_depend>
-  <run_depend>visualization_msgs</run_depend>
-  <run_depend>jsk_footstep_msgs</run_depend>
-  <run_depend>jsk_interactive_marker</run_depend>
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>diagnostic_updater</run_depend>
-  <run_depend>jsk_rviz_plugins</run_depend>
-  <run_depend>joy_mouse</run_depend>
-  <run_depend>image_view2</run_depend>
-  <run_depend>python-pygame</run_depend>
+  <exec_depend>ps3joy</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>view_controller_msgs</exec_depend>
+  <exec_depend>interactive_markers</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend>jsk_footstep_msgs</exec_depend>
+  <exec_depend>jsk_interactive_marker</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>diagnostic_updater</exec_depend>
+  <exec_depend>jsk_rviz_plugins</exec_depend>
+  <exec_depend>joy_mouse</exec_depend>
+  <exec_depend>image_view2</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pygame</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pygame</exec_depend>
 
   <export>
     <jsk_teleop_joy plugin="${prefix}/plugin.xml"/>


### PR DESCRIPTION
`python-pygame` is Python 2 package.
We need to install `python3-pygame` instead on noetic.