### PR TITLE
[jsk_teleop_joy] [MIDI] Add sample launch

### DIFF
--- a/jsk_teleop_joy/README.md
+++ b/jsk_teleop_joy/README.md
@@ -142,5 +142,10 @@ the configuration to a yaml file by `-w` option.
 This script publishes `sensor_msgs/Joy` to `/joy` based on a yaml file
 configured by `interactive_midi_config.py` and `midi_write.py`.
 
+You can launch the program as follows.
+```bash
+roslaunch jsk_teleop_joy midi_controller.launch midi_config:=[your config file]
+```
+
 [`configs`](configs) directory includes some yaml files for several MIDI
 devices.

--- a/jsk_teleop_joy/launch/midi_controller.launch
+++ b/jsk_teleop_joy/launch/midi_controller.launch
@@ -1,0 +1,10 @@
+<launch>
+  <arg name="midi_config" default="launchpad_x.yaml" />
+
+  <!-- MIDI controller -->
+  <node pkg="jsk_teleop_joy" type="midi_config_player.py"
+        output="screen" name="midi_controller"
+        args="$(find jsk_teleop_joy)/configs/$(arg midi_config)">
+    <remap from="/joy" to="/midi_controller/joy" />
+  </node>
+</launch>


### PR DESCRIPTION
There was no launch file that launched `midi_config_player.py`, so I added a simple launch file for the sample.

You can launch midi_config_player.py program as follows.
```bash
roslaunch jsk_teleop_joy midi_controller.launch midi_config:=[your config file]
```
