### PR TITLE
ros-o support

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -93,3 +93,105 @@ jobs:
           ROS_PARALLEL_TEST_JOBS: "-j4"
           CATKIN_TOOLS_BUILD_OPTIONS: "-iv --summarize --no-status"
           BUILD_PKGS : ${{ matrix.BUILD_PKGS }}
+
+ # ROS-O setup for v4hn https://github.com/v4hn/ros-o-builder/blob/jammy-one/README.md#install-instructions
+  # ROS-O setup for techfak https://ros.packages.techfak.net/
+  # note that v4hn uses ROS_DISTRO=one and techfak uses ROS_DISTRO
+  ros-o:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - DISTRO: ubuntu:22.04
+            ROS_ONE_VARIANT: techfak
+            ROS_REPOSITORY_URL: "deb [trusted=yes] https://ros.packages.techfak.net jammy-testing main"
+            ROSDEP_PACKAGE_MAPPING: "yaml https://ros.packages.techfak.net/ros-one.yaml ubuntu"
+          - DISTRO: ubuntu:24.04
+            ROS_ONE_VARIANT: techfak
+            ROS_REPOSITORY_URL: "deb [trusted=yes] https://ros.packages.techfak.net noble-testing main"
+            ROSDEP_PACKAGE_MAPPING: "yaml https://ros.packages.techfak.net/ros-one.yaml ubuntu"
+
+    container: ${{ matrix.DISTRO }}
+
+    env:
+      DEBIAN_FRONTEND : noninteractive
+
+    steps:
+      - name: Chcekout Source
+        uses: actions/checkout@v3.0.2
+
+      - name: Setup ROS-O deb repository
+        run: |
+          set -x
+          apt update && apt install -qq -y ca-certificates git
+          echo ${{ matrix.ROS_REPOSITORY_URL }} | tee /etc/apt/sources.list.d/ros-o-builder.list
+          ##
+          # https://github.com/v4hn/ros-deb-builder-action/blob/b7c0ed93fde3a86b5b1027bf8f7145cad6067c90/prepare.sh#L27-L28
+          # Canonical dropped the Debian ROS packages from 24.04 for political reasons. Wow.
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "v4hn" && "${{ matrix.DISTRO }}" == "ubuntu:24.04" ]]; then apt install -y software-properties-common retry && retry -d 50,10,30,300 -t 12 add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/ros; fi
+          ##
+          apt update
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "v4hn" ]]; then
+              apt install -qq -y python3-rosdep2
+          fi
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "techfak"  ]]; then
+              # Do not install python3-rosdep2, which is an outdated version of rosdep shipped via the Ubuntu repositories (instead of ROS)!
+              apt install -qq -y python3-rosdep
+              rosdep init
+          fi
+          echo ${{ matrix.ROSDEP_PACKAGE_MAPPING }} | tee /etc/ros/rosdep/sources.list.d/1-ros-o-builder.list
+          rosdep update
+        shell: bash
+
+      - name: Setup catkin-tools
+        run: |
+          set -x
+          # setup catkin tools
+          apt install -qq -y python3-pip
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "v4hn" ]]; then
+              pip3 install catkin-tools==0.9.4
+              apt install -qq -y catkin
+          fi
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "techfak" ]]; then
+              apt install -qq -y ros-one-catkin python3-catkin-tools
+          fi
+          # setup build tools
+          apt install -qq -y cmake build-essential ros-one-rosbash
+        shell: bash
+
+      - name: Setup Workspace
+        run: |
+          source /opt/ros/one/setup.bash
+          set -x
+          # setup workspace
+          mkdir -p ~/ws/src
+          cd ~/ws/src
+          ln -sf $GITHUB_WORKSPACE .
+          rosdep install -qq -r -y --from-path . --ignore-src || echo "OK"
+          # check all system packages are able to install, because ROS-O build deb files that needs all packages
+          PIP_BREAK_SYSTEM_PACKAGES=1 rosdep install -qq --simulate -y --from-path . --ignore-src -t exec -t buildtool_export -t buildtool -t build -t build_export | tee rosdep-install.sh
+          # catkin_tools is not available on v4hn/jammy
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "v4hn" ]]; then sed -i '/python3-catkin-tools/s/^/#/' rosdep-install.sh; fi
+          sed 's/apt-get install/apt-get -y install/;/install ros-one/s/^/#/;/pip3 install/s/^/#/' rosdep-install.sh | bash -xe
+        shell: bash
+
+      - name: Compile Packages
+        run: |
+          source /opt/ros/one/setup.bash
+          set -x
+          cd ~/ws/
+          catkin build --no-status -sv ${{ matrix.CATKIN_OPTIONS }} --cmake-args -DCATKIN_ENABLE_TESTING=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${{ matrix.CMAKE_OPTIONS }}
+        shell: bash
+
+      - name: Test Packages
+        run: |
+          source /opt/ros/one/setup.bash
+          set -x
+          cd ~/ws/
+          rosdep install -qq -r -y --from-path . --ignore-src || echo "OK"
+          catkin build --force-cmake --no-status -sv ${{ matrix.CATKIN_OPTIONS }} --cmake-args -DCATKIN_ENABLE_TESTING=ON -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${{ matrix.CMAKE_OPTIONS }}
+          catkin test --no-status -sv ${{ matrix.CATKIN_OPTIONS }} --cmake-args -DCATKIN_ENABLE_TESTING=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${{ matrix.CMAKE_OPTIONS }}
+           catkin_test_results --verbose --all
+        shell: bash

--- a/eus_qp/CMakeLists.txt
+++ b/eus_qp/CMakeLists.txt
@@ -20,14 +20,17 @@ catkin_package()
 
 add_executable(euq_qp_test src/example.cpp)
 add_library(eus_qp SHARED src/qp_lib.cpp)
-add_rostest(test/test_contact_wrench_opt.test)
-add_rostest(test/test_model_predictive_control.test)
-add_rostest(test/test_cfr_cwc_calculation.test)
-add_rostest(optmotiongen/test/test-sample-inverse-kinematics.test)
-add_rostest(optmotiongen/test/test-sample-inverse-kinematics-statics.test)
-add_rostest(optmotiongen/test/test-samplerobot.test)
-add_rostest(optmotiongen/test/test-sample-torque-gradient.test)
-add_rostest(optmotiongen/test/test-load-euslisp-files.test)
+
+if(CATKIN_ENABLE_TESTING)
+  add_rostest(test/test_contact_wrench_opt.test)
+  add_rostest(test/test_model_predictive_control.test)
+  add_rostest(test/test_cfr_cwc_calculation.test)
+  add_rostest(optmotiongen/test/test-sample-inverse-kinematics.test)
+  add_rostest(optmotiongen/test/test-sample-inverse-kinematics-statics.test)
+  add_rostest(optmotiongen/test/test-samplerobot.test)
+  add_rostest(optmotiongen/test/test-sample-torque-gradient.test)
+  add_rostest(optmotiongen/test/test-load-euslisp-files.test)
+endif()
 
 install(DIRECTORY euslisp test
   USE_SOURCE_PERMISSIONS

--- a/eus_qpoases/CMakeLists.txt
+++ b/eus_qpoases/CMakeLists.txt
@@ -36,7 +36,9 @@ set_target_properties(eus_qpoases PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_
 add_dependencies(eus_qpoases qpoases)
 target_link_libraries(eus_qpoases qpOASES)
 
-add_rostest(test/eus_qpoases.test)
+if(CATKIN_ENABLE_TESTING)
+  add_rostest(test/eus_qpoases.test)
+endif()
 
 install(DIRECTORY lib/
   USE_SOURCE_PERMISSIONS

--- a/eus_qpoases/CMakeLists.txt
+++ b/eus_qpoases/CMakeLists.txt
@@ -9,7 +9,7 @@ ExternalProject_Add(qpoases
   GIT_REPOSITORY https://github.com/coin-or/qpOASES
   GIT_TAG releases/3.0.1
   TIMEOUT 30
-  PATCH_COMMAND patch -s -p0 < ${PROJECT_SOURCE_DIR}/patch/UseShareLibrary.patch
+  PATCH_COMMAND patch -s -p0 --forward < ${PROJECT_SOURCE_DIR}/patch/UseShareLibrary.patch || true # # If there is no --forward, the build process hangs because the patch command waits interactively for input on whether a file that has already been patched can be patched again. If there is no || true , the patch command returns non-zero status.
   CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
   BUILD_COMMAND make -j
   BUILD_IN_SOURCE 1

--- a/eus_qpoases/src/eus_qpoases.cpp
+++ b/eus_qpoases/src/eus_qpoases.cpp
@@ -272,7 +272,7 @@ extern "C" {
                             double* state_min_vector, double* state_max_vector,
                             double* inequality_matrix, double* inequality_min_vector, double* inequality_max_vector,
                             int state_len, int inequality_len, PrintLevel print_level, double* ret_status) {
-    solve_qpoases_qp_common(ret,
+    return solve_qpoases_qp_common(ret,
                             eval_weight_matrix, eval_coeff_vector,
                             state_min_vector, state_max_vector,
                             inequality_matrix, inequality_min_vector, inequality_max_vector,
@@ -284,7 +284,7 @@ extern "C" {
                             double* state_min_vector, double* state_max_vector,
                             double* inequality_matrix, double* inequality_min_vector, double* inequality_max_vector,
                             int state_len, int inequality_len, PrintLevel print_level, double* ret_status) {
-    solve_qpoases_qp_common(ret,
+    return solve_qpoases_qp_common(ret,
                             NULL, eval_coeff_vector,
                             state_min_vector, state_max_vector,
                             inequality_matrix, inequality_min_vector, inequality_max_vector,
@@ -296,7 +296,7 @@ extern "C" {
                                           double* state_min_vector, double* state_max_vector,
                                           double* inequality_matrix, double* inequality_min_vector, double* inequality_max_vector,
                                           int state_len, int inequality_len, PrintLevel print_level, double* ret_status) {
-    solve_qpoases_qp_with_hotstart_common(ret,
+    return solve_qpoases_qp_with_hotstart_common(ret,
                                           eval_weight_matrix, eval_coeff_vector,
                                           state_min_vector, state_max_vector,
                                           inequality_matrix, inequality_min_vector, inequality_max_vector,
@@ -308,7 +308,7 @@ extern "C" {
                                           double* state_min_vector, double* state_max_vector,
                                           double* inequality_matrix, double* inequality_min_vector, double* inequality_max_vector,
                                           int state_len, int inequality_len, PrintLevel print_level, double* ret_status) {
-    solve_qpoases_qp_with_hotstart_common(ret,
+    return solve_qpoases_qp_with_hotstart_common(ret,
                                           NULL, eval_coeff_vector,
                                           state_min_vector, state_max_vector,
                                           inequality_matrix, inequality_min_vector, inequality_max_vector,
@@ -320,7 +320,7 @@ extern "C" {
                                            double* state_min_vector, double* state_max_vector,
                                            double* inequality_matrix, double* inequality_min_vector, double* inequality_max_vector,
                                            int state_len, int inequality_len, PrintLevel print_level, double* ret_status) {
-    solve_qpoases_sqp_with_hotstart_common(ret,
+    return solve_qpoases_sqp_with_hotstart_common(ret,
                                            eval_weight_matrix, eval_coeff_vector,
                                            state_min_vector, state_max_vector,
                                            inequality_matrix, inequality_min_vector, inequality_max_vector,
@@ -332,7 +332,7 @@ extern "C" {
                                            double* state_min_vector, double* state_max_vector,
                                            double* inequality_matrix, double* inequality_min_vector, double* inequality_max_vector,
                                            int state_len, int inequality_len, PrintLevel print_level, double* ret_status) {
-    solve_qpoases_sqp_with_hotstart_common(ret,
+    return solve_qpoases_sqp_with_hotstart_common(ret,
                                            NULL, eval_coeff_vector,
                                            state_min_vector, state_max_vector,
                                            inequality_matrix, inequality_min_vector, inequality_max_vector,

--- a/eus_teleop/package.xml
+++ b/eus_teleop/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>eus_teleop</name>
   <version>0.1.18</version>
   <description>The eus_teleop package</description>
@@ -14,9 +14,9 @@
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>actionlib_msgs</exec_depend>
-  <exec_depend>baxter_core_msgs</exec_depend>
-  <exec_depend>baxtereus</exec_depend>
-  <exec_depend>influxdb_store</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != one">baxter_core_msgs</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != one">baxtereus</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != one">influxdb_store</exec_depend>
   <exec_depend>jsk_interactive_marker</exec_depend>
   <exec_depend>jsk_topic_tools</exec_depend>
   <exec_depend>libuvc_camera</exec_depend>
@@ -24,12 +24,12 @@
   <exec_depend>pr2eus</exec_depend>
   <exec_depend>roseus</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>softhand_ros</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != one">softhand_ros</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>video_stream_opencv</exec_depend>
-  <exec_depend>vive_ros</exec_depend>
-  <exec_depend>pr2_moveit_config</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != one">vive_ros</exec_depend>
+  <exec_depend condition="$ROS_DISTRO != one">pr2_moveit_config</exec_depend>
 
   <export>
   </export>

--- a/jsk_footstep_planner/CMakeLists.txt
+++ b/jsk_footstep_planner/CMakeLists.txt
@@ -106,4 +106,6 @@ install(TARGETS jsk_footstep_planner sample_astar sample_simple_graph
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-add_rostest(test/test_footstep_planning_eus_client.test)
+if(CATKIN_ENABLE_TESTING)
+  add_rostest(test/test_footstep_planning_eus_client.test)
+endif()

--- a/jsk_footstep_planner/include/jsk_footstep_planner/footstep_state.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/footstep_state.h
@@ -39,6 +39,7 @@
 
 #include <jsk_footstep_msgs/Footstep.h>
 
+#include <pcl/common/transforms.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/filters/crop_box.h>
 #include <pcl/sample_consensus/method_types.h>

--- a/jsk_footstep_planner/include/jsk_footstep_planner/grid_path_planner.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/grid_path_planner.h
@@ -16,6 +16,7 @@
 #include <jsk_footstep_planner/CollisionBoundingBoxInfo.h>
 
 // pcl
+#include <pcl/common/common.h>
 #include <pcl/kdtree/kdtree_flann.h>
 
 // grid path planning

--- a/jsk_footstep_planner/include/jsk_footstep_planner/pointcloud_model_generator.h
+++ b/jsk_footstep_planner/include/jsk_footstep_planner/pointcloud_model_generator.h
@@ -37,6 +37,7 @@
 #ifndef JSK_FOOTSTEP_PLANNER_POINTCLOUD_MODEL_GENERATOR_H_
 #define JSK_FOOTSTEP_PLANNER_POINTCLOUD_MODEL_GENERATOR_H_
 
+#include <boost/shared_ptr.hpp>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 


### PR DESCRIPTION
d344b4c Ensure the return value is propagated correctly
2b6bb0d [ci] enable ros-o test
007a981 [jsk_footstep_planner] fix pcl related compilation issues in noble
efe1ae3 eusqp: add CATKIN_ENABLE_TESTING for add_rostest
7889cb8 jsk_footstep_planner/CMakeLists.txt: add CATKIN_ENABLE_TESTING for add_rostest
08df911 [eus_teleop] skip some keys when ROS_DISTRO==one. ref: https://github.com/tork-a/jsk_control-release/blob/debian/noetic/eus_teleop/package.xml
31f05a7 qpoasis: use patch --forward for fakeroot debian/rules
3682aff eus_qpoases/CMakeLists.txt: add CATKIN_ENABLE_TESTING for add_rostest
